### PR TITLE
Update target framework to .NET 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4
       with:
-        global-json-file: global.json
+        dotnet-version: |
+          9.x
+          10.x
     - name: Restore
       run: dotnet restore DcmSharp.CI.slnf
     - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <!-- C# Version -->
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
 
     <!-- Packaging -->

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.0",
+    "version": "10.0.0",
     "rollForward": "latestFeature"
   }
 }

--- a/src/DcmOrganize/DcmOrganize.csproj
+++ b/src/DcmOrganize/DcmOrganize.csproj
@@ -9,6 +9,5 @@
     <PackageReference Include="KeyedSemaphores" />
     <PackageReference Include="Polly" />
     <PackageReference Include="System.CommandLine" />
-    <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
 </Project>

--- a/src/DcmSharp/DcmSharp.csproj
+++ b/src/DcmSharp/DcmSharp.csproj
@@ -16,7 +16,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
-    <PackageReference Include="System.IO.Pipelines"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Update="ReadOnlyDicomDataset.TryGetDate.cs">


### PR DESCRIPTION
## Summary

- Bump `global.json` SDK version from `9.0.0` to `10.0.0`
- Change `TargetFramework` from `net9.0` to `net10.0` in `Directory.Build.props`
- Replace `global-json-file` CI step with explicit `dotnet-version: 9.x / 10.x` so the runner installs both SDKs (source generator still targets `netstandard2.0` and needs the 9.x toolchain)
- Remove `PackageReference` for `System.IO.Pipelines` and `System.Threading.Channels` — both are inbox on .NET 10 and the SDK now emits **NU1510** (treated as error) when they are referenced explicitly

## Test plan

- [x] `dotnet build DcmSharp.CI.slnf --configuration Release` passes with 0 errors
- [x] All 5783 tests pass on net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)