### PR TITLE
Migrate xUnit from v2 to v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="fo-dicom.Imaging.ImageSharp" Version="5.2.6" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageVersion Include="KeyedSemaphores" Version="6.1.0" />
-    <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
+    <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.50" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
@@ -36,7 +36,7 @@
     <PackageVersion Include="System.IO.Pipelines" Version="10.0.6" />
     <PackageVersion Include="System.Text.Json" Version="10.0.6" />
     <PackageVersion Include="System.Threading.Channels" Version="10.0.6" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/tests/DcmAnonymize.Tests/DcmAnonymize.Tests.csproj
+++ b/tests/DcmAnonymize.Tests/DcmAnonymize.Tests.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DcmAnonymize.Tests/TestsForDicomAnonymizer.cs
+++ b/tests/DcmAnonymize.Tests/TestsForDicomAnonymizer.cs
@@ -429,8 +429,14 @@ public class TestsForDicomAnonymizer
 
         // Act
         await Task.WhenAll(
-            Task.Run(() => _anonymizer.AnonymizeAsync(metaInfo1, dataSet1, _options)),
-            Task.Run(() => _anonymizer.AnonymizeAsync(metaInfo2, dataSet2, _options))
+            Task.Run(
+                () => _anonymizer.AnonymizeAsync(metaInfo1, dataSet1, _options),
+                TestContext.Current.CancellationToken
+            ),
+            Task.Run(
+                () => _anonymizer.AnonymizeAsync(metaInfo2, dataSet2, _options),
+                TestContext.Current.CancellationToken
+            )
         );
 
         // Assert

--- a/tests/DcmAnonymize.Tests/TestsForProgram.cs
+++ b/tests/DcmAnonymize.Tests/TestsForProgram.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace DcmAnonymize.Tests;
 
@@ -23,7 +22,7 @@ public class TestsForDcmAnonymize : IAsyncLifetime
             testOutputHelper ?? throw new ArgumentNullException(nameof(testOutputHelper));
     }
 
-    public Task InitializeAsync()
+    public ValueTask InitializeAsync()
     {
         var testDataDirectory = new DirectoryInfo("./TestData");
         var sampleDicomFile = new FileInfo(
@@ -45,10 +44,10 @@ public class TestsForDcmAnonymize : IAsyncLifetime
             Output = _outputWriter,
             ErrorOutput = _errorOutputWriter,
         };
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _outputWriter.DisposeAsync();
         await _errorOutputWriter.DisposeAsync();

--- a/tests/DcmFind.Tests/DcmFind.Tests.csproj
+++ b/tests/DcmFind.Tests/DcmFind.Tests.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DcmFind.Tests/TestsForDcmFind.cs
+++ b/tests/DcmFind.Tests/TestsForDcmFind.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace DcmFind.Tests;
 

--- a/tests/DcmOrganize.Tests/DcmOrganize.Tests.csproj
+++ b/tests/DcmOrganize.Tests/DcmOrganize.Tests.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DcmOrganize.Tests/TestsForLinesFromConsoleInputReader.cs
+++ b/tests/DcmOrganize.Tests/TestsForLinesFromConsoleInputReader.cs
@@ -21,7 +21,9 @@ public class TestsForLinesFromConsoleInputReader : IDisposable
     [Fact]
     public async Task ShouldReadEmptyString()
     {
-        var lines = await _linesFromConsoleInputReader.Read(CancellationToken.None).ToListAsync();
+        var lines = await _linesFromConsoleInputReader
+            .Read(TestContext.Current.CancellationToken)
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         lines.Should().BeEmpty();
     }
@@ -32,7 +34,9 @@ public class TestsForLinesFromConsoleInputReader : IDisposable
         _consoleInputWriter.Write("Hello world");
         _consoleInputStream.Seek(0, SeekOrigin.Begin);
 
-        var lines = await _linesFromConsoleInputReader.Read(CancellationToken.None).ToListAsync();
+        var lines = await _linesFromConsoleInputReader
+            .Read(TestContext.Current.CancellationToken)
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         lines.Should().BeEquivalentTo(new[] { "Hello world" });
     }
@@ -46,7 +50,9 @@ public class TestsForLinesFromConsoleInputReader : IDisposable
         _consoleInputWriter.Write(input);
         _consoleInputStream.Seek(0, SeekOrigin.Begin);
 
-        var lines = await _linesFromConsoleInputReader.Read(CancellationToken.None).ToListAsync();
+        var lines = await _linesFromConsoleInputReader
+            .Read(TestContext.Current.CancellationToken)
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         lines.Should().BeEquivalentTo(new[] { "Hello", "World" });
     }

--- a/tests/DcmSharp.SourceGenerator.Tests/DcmSharp.SourceGenerator.Tests.csproj
+++ b/tests/DcmSharp.SourceGenerator.Tests/DcmSharp.SourceGenerator.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -8,7 +9,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DcmSharp.SourceGenerator.Tests/DicomTagsGeneratorTests.cs
+++ b/tests/DcmSharp.SourceGenerator.Tests/DicomTagsGeneratorTests.cs
@@ -211,6 +211,6 @@ public class TestsForDicomTagsGenerator
         };
 
         // Act
-        await test.RunAsync();
+        await test.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/DcmSharp.Tests/DcmSharp.Tests.csproj
+++ b/tests/DcmSharp.Tests/DcmSharp.Tests.csproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="MartinCostello.Logging.XUnit" />
+    <PackageReference Include="MartinCostello.Logging.XUnit.v3" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DcmSharp.Tests/DicomParserFixture.cs
+++ b/tests/DcmSharp.Tests/DicomParserFixture.cs
@@ -2,7 +2,6 @@
 using MartinCostello.Logging.XUnit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace DcmSharp.Tests;
 

--- a/tests/DcmSharp.Tests/TestsForDicomEncoding.cs
+++ b/tests/DcmSharp.Tests/TestsForDicomEncoding.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text;
 using DcmSharp.Parser;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace DcmSharp.Tests;
 
@@ -21,7 +20,10 @@ public sealed class TestsForDicomEncoding
     {
         // Arrange
         var file = new FileInfo("./Dicom/Encoded.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset

--- a/tests/DcmSharp.Tests/TestsForDicomMultiValues.cs
+++ b/tests/DcmSharp.Tests/TestsForDicomMultiValues.cs
@@ -1,6 +1,5 @@
 ﻿using DcmSharp.Parser;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace DcmSharp.Tests;
 
@@ -20,7 +19,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -37,7 +39,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -54,7 +59,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -73,7 +81,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -92,7 +103,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -109,7 +123,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -131,7 +148,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -148,7 +168,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetFloats(DicomTags.SelectorFLValue, out float[] values).Should().BeTrue();
@@ -162,7 +185,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetInts(DicomTags.SelectorISValue, out int[] values).Should().BeTrue();
@@ -176,7 +202,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -193,7 +222,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -210,7 +242,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -229,7 +264,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -246,7 +284,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetInts(DicomTags.SelectorSLValue, out int[] values).Should().BeTrue();
@@ -260,7 +301,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetShorts(DicomTags.SelectorSSValue, out short[] values).Should().BeTrue();
@@ -274,7 +318,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -291,7 +338,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetLongs(DicomTags.SelectorSVValue, out long[] values).Should().BeTrue();
@@ -305,7 +355,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -322,7 +375,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -339,7 +395,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -356,7 +415,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetUInts(DicomTags.SelectorULValue, out uint[] values).Should().BeTrue();
@@ -371,7 +433,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -388,7 +453,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -405,7 +473,10 @@ public sealed class TestsForDicomMultiValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/MultiValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetULongs(DicomTags.SelectorUVValue, out ulong[] values).Should().BeTrue();

--- a/tests/DcmSharp.Tests/TestsForDicomParser.cs
+++ b/tests/DcmSharp.Tests/TestsForDicomParser.cs
@@ -1,6 +1,5 @@
 using DcmSharp.Parser;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace DcmSharp.Tests;
 
@@ -22,7 +21,10 @@ public sealed class TestsForDicomParser
         var file = new FileInfo("./Dicom/ExplicitVR.dcm");
 
         // Act + Assert
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Assert
         dicomDataset.Should().NotBeNull();
@@ -35,7 +37,10 @@ public sealed class TestsForDicomParser
         var file = new FileInfo("./Dicom/ImplicitVR.dcm");
 
         // Act + Assert
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Assert
         dicomDataset.Should().NotBeNull();
@@ -52,7 +57,10 @@ public sealed class TestsForDicomParser
     {
         // Arrange
         var file = new FileInfo("./Dicom/ExplicitVR.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetString(group, element, out string? actualValue).Should().BeTrue();
@@ -72,7 +80,10 @@ public sealed class TestsForDicomParser
     {
         // Arrange
         var file = new FileInfo("./Dicom/ImplicitVR.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetString(group, element, out string? actualValue).Should().BeTrue();
@@ -86,7 +97,10 @@ public sealed class TestsForDicomParser
     {
         // Arrange
         var file = new FileInfo("./Dicom/TestPatternPalette.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act + Assert
         dicomDataset
@@ -120,7 +134,10 @@ public sealed class TestsForDicomParser
     {
         // Arrange
         var file = new FileInfo("./Dicom/Encoded.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset

--- a/tests/DcmSharp.Tests/TestsForDicomParserWithStopping.cs
+++ b/tests/DcmSharp.Tests/TestsForDicomParserWithStopping.cs
@@ -1,6 +1,5 @@
 using DcmSharp.Parser;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace DcmSharp.Tests;
 
@@ -32,7 +31,11 @@ public sealed class TestsForDicomParserWithStopping
         };
 
         // Act + Assert
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file, options);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            options,
+            TestContext.Current.CancellationToken
+        );
 
         // Assert
         dicomDataset.Should().NotBeNull();
@@ -65,7 +68,11 @@ public sealed class TestsForDicomParserWithStopping
         };
 
         // Act + Assert
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file, options);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            options,
+            TestContext.Current.CancellationToken
+        );
 
         // Assert
         dicomDataset.Should().NotBeNull();
@@ -93,7 +100,11 @@ public sealed class TestsForDicomParserWithStopping
                 Depth = 2,
             },
         };
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file, options);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            options,
+            TestContext.Current.CancellationToken
+        );
 
         // Act + Assert
         dicomDataset
@@ -139,7 +150,11 @@ public sealed class TestsForDicomParserWithStopping
         };
 
         // Act
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file, options);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            options,
+            TestContext.Current.CancellationToken
+        );
         dicomDataset
             .TryGetString(DicomTags.PlacerOrderNumberImagingServiceRequest, out string? orderNumber)
             .Should()

--- a/tests/DcmSharp.Tests/TestsForDicomSingleValues.cs
+++ b/tests/DcmSharp.Tests/TestsForDicomSingleValues.cs
@@ -1,6 +1,5 @@
 ﻿using DcmSharp.Parser;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace DcmSharp.Tests;
 
@@ -20,7 +19,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetString(DicomTags.SelectorAEValue, out string? value).Should().BeTrue();
@@ -34,7 +36,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetString(DicomTags.SelectorASValue, out string? value).Should().BeTrue();
@@ -48,7 +53,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetTag(DicomTags.SelectorATValue, out DicomTag? value).Should().BeTrue();
@@ -62,7 +70,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetDate(DicomTags.SelectorDAValue, out DateOnly value).Should().BeTrue();
@@ -76,7 +87,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetDecimal(DicomTags.SelectorDSValue, out decimal value).Should().BeTrue();
@@ -90,7 +104,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -107,7 +124,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetDouble(DicomTags.SelectorFDValue, out double value).Should().BeTrue();
@@ -121,7 +141,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetFloat(DicomTags.SelectorFLValue, out float value).Should().BeTrue();
@@ -135,7 +158,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetInt(DicomTags.SelectorISValue, out int value).Should().BeTrue();
@@ -149,7 +175,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetString(DicomTags.SelectorLOValue, out string? value).Should().BeTrue();
@@ -163,7 +192,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetString(DicomTags.SelectorLTValue, out string? value).Should().BeTrue();
@@ -177,7 +209,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset
@@ -195,7 +230,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetString(DicomTags.SelectorSHValue, out string? value).Should().BeTrue();
@@ -209,7 +247,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetInt(DicomTags.SelectorSLValue, out int value).Should().BeTrue();
@@ -223,7 +264,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetShort(DicomTags.SelectorSSValue, out short value).Should().BeTrue();
@@ -237,7 +281,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetString(DicomTags.SelectorSTValue, out string? value).Should().BeTrue();
@@ -251,7 +298,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetLong(DicomTags.SelectorSVValue, out long value).Should().BeTrue();
@@ -265,7 +315,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetTime(DicomTags.SelectorTMValue, out TimeOnly value).Should().BeTrue();
@@ -279,7 +332,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetString(DicomTags.SelectorUCValue, out string? value).Should().BeTrue();
@@ -293,7 +349,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetString(DicomTags.SelectorUIValue, out string? value).Should().BeTrue();
@@ -307,7 +366,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetUInt(DicomTags.SelectorULValue, out uint value).Should().BeTrue();
@@ -321,7 +383,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetUShort(DicomTags.SelectorUSValue, out ushort value).Should().BeTrue();
@@ -335,7 +400,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetString(DicomTags.SelectorUTValue, out string? value).Should().BeTrue();
@@ -349,7 +417,10 @@ public sealed class TestsForDicomSingleValues
     {
         // Arrange
         var file = new FileInfo("./Dicom/SingleValues.dcm");
-        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
+        using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(
+            file,
+            TestContext.Current.CancellationToken
+        );
 
         // Act
         dicomDataset.TryGetULong(DicomTags.SelectorUVValue, out ulong value).Should().BeTrue();


### PR DESCRIPTION
## Summary

- Replace \`xunit\` 2.9.2 with \`xunit.v3\` 3.2.2
- Update \`xunit.runner.visualstudio\` to 3.1.5
- Replace \`MartinCostello.Logging.XUnit\` with \`MartinCostello.Logging.XUnit.v3\` 0.7.1
- Set \`OutputType\` to \`Exe\` in all test projects — xUnit v3 test projects are stand-alone executables
- Remove \`using Xunit.Abstractions\` — \`ITestOutputHelper\` moved to the \`Xunit\` namespace in v3
- Change \`IAsyncLifetime\` methods to return \`ValueTask\` instead of \`Task\`
- Pass \`TestContext.Current.CancellationToken\` to all calls that accept an optional \`CancellationToken\`, satisfying the new xUnit1051 analyzer rule
- Remove the now-redundant manual \`CancellationTokenSource\` in \`DcmFind\` (the \`ExecuteAsync\` override already receives one from Spectre.Console)

## Test plan
- [ ] Build succeeds with 0 warnings and 0 errors
- [ ] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)