### PR TITLE
feat: introduce strongly-typed DicomTag<T> with compile-time type safety

### DIFF
--- a/src/DcmSharp.SourceGenerator/DicomTagsGenerator.cs
+++ b/src/DcmSharp.SourceGenerator/DicomTagsGenerator.cs
@@ -205,9 +205,9 @@ namespace DcmSharp.SourceGenerator
                 case "PN":
                     return isSingleValued ? "PersonName" : "PersonName[]";
 
-                // Attribute Tag
+                // Attribute Tag — no typed TryGet overloads yet, remain untyped
                 case "AT":
-                    return isSingleValued ? "DicomTag" : "DicomTag[]";
+                    return null;
 
                 // Binary data VRs — always opaque bytes
                 case "OB":

--- a/src/DcmSharp.SourceGenerator/DicomTagsGenerator.cs
+++ b/src/DcmSharp.SourceGenerator/DicomTagsGenerator.cs
@@ -66,6 +66,11 @@ namespace DcmSharp.SourceGenerator
                 string group = tagParts[0].Trim().Replace("X", "0");
                 string element = tagParts[1].Trim().Replace("X", "0");
 
+                // Determine if we can emit a strongly-typed DicomTag<T>
+                string? clrType = GetClrType(vrs, vm);
+                bool isTyped = clrType != null;
+                string tagTypeName = isTyped ? $"DicomTag<{clrType}>" : "DicomTag";
+
                 sourceBuilder.AppendLine($"    /// <summary>");
                 sourceBuilder.AppendLine($"    /// {tag} {EscapeXmlComment(name!)}");
                 foreach (string vr in vrs)
@@ -79,7 +84,7 @@ namespace DcmSharp.SourceGenerator
                 {
                     sourceBuilder.AppendLine($"    [Obsolete(\"This DICOM tag is retired.\")]");
                 }
-                sourceBuilder.Append($"    public static readonly DicomTag {keyword} = new DicomTag(");
+                sourceBuilder.Append($"    public static readonly {tagTypeName} {keyword} = new {tagTypeName}(");
                 // Group
                 sourceBuilder.Append($"0x{group}");
                 // Element
@@ -134,6 +139,91 @@ namespace DcmSharp.SourceGenerator
             sourceBuilder.AppendLine("");
 
             context.AddSource("DicomTags.g.cs", SourceText.From(sourceBuilder.ToString(), Encoding.UTF8));
+        }
+
+        /// <summary>
+        /// Maps a VR + VM combination to the CLR type for DicomTag&lt;T&gt;.
+        /// Returns null if the tag should remain untyped (multi-VR tags, unknown VRs, sequences).
+        /// </summary>
+        private static string? GetClrType(string[] vrs, string vm)
+        {
+            // Multi-VR tags (e.g. "US or SS") remain untyped — ambiguous at compile time
+            if (vrs.Length != 1)
+                return null;
+
+            string vr = vrs[0];
+            bool isSingleValued = vm == "VM_1";
+
+            switch (vr)
+            {
+                // String-based VRs
+                case "AE":
+                case "AS":
+                case "CS":
+                case "DS":
+                case "IS":
+                case "LO":
+                case "SH":
+                case "UC":
+                case "UI":
+                    return isSingleValued ? "string" : "string[]";
+
+                // Always single-valued text VRs (VM is always 1 by definition)
+                case "LT":
+                case "ST":
+                case "UT":
+                case "UR":
+                    return "string";
+
+                // Date/Time
+                case "DA":
+                    return isSingleValued ? "DateOnly" : "DateOnly[]";
+                case "TM":
+                    return isSingleValued ? "TimeOnly" : "TimeOnly[]";
+                case "DT":
+                    return isSingleValued ? "DateTime" : "DateTime[]";
+
+                // Numeric
+                case "SS":
+                    return isSingleValued ? "short" : "short[]";
+                case "US":
+                    return isSingleValued ? "ushort" : "ushort[]";
+                case "SL":
+                    return isSingleValued ? "int" : "int[]";
+                case "UL":
+                    return isSingleValued ? "uint" : "uint[]";
+                case "SV":
+                    return isSingleValued ? "long" : "long[]";
+                case "UV":
+                    return isSingleValued ? "ulong" : "ulong[]";
+                case "FL":
+                    return isSingleValued ? "float" : "float[]";
+                case "FD":
+                    return isSingleValued ? "double" : "double[]";
+
+                // Person Name
+                case "PN":
+                    return isSingleValued ? "PersonName" : "PersonName[]";
+
+                // Attribute Tag
+                case "AT":
+                    return isSingleValued ? "DicomTag" : "DicomTag[]";
+
+                // Binary data VRs — always opaque bytes
+                case "OB":
+                case "OD":
+                case "OF":
+                case "OL":
+                case "OW":
+                case "OV":
+                case "UN":
+                    return "ReadOnlyMemory<byte>";
+
+                // Sequences and unknown — remain untyped
+                case "SQ":
+                default:
+                    return null;
+            }
         }
 
         private static string EscapeXmlComment(string text)

--- a/src/DcmSharp/DicomDataset.Set.Typed.cs
+++ b/src/DcmSharp/DicomDataset.Set.Typed.cs
@@ -1,0 +1,39 @@
+namespace DcmSharp;
+
+public sealed partial record DicomDataset
+{
+    public void Set(DicomTag<string> tag, string value) => Add(DicomItemFactory.Create(tag, value));
+
+    public void Set(DicomTag<DateOnly> tag, DateOnly value) => Add(DicomItemFactory.Create(tag, value));
+
+    public void Set(DicomTag<int> tag, int value) => Add(DicomItemFactory.Create(tag, value));
+
+    public void Set(DicomTag<ushort> tag, ushort value) => Add(DicomItemFactory.Create(tag, value));
+
+    public void Set(DicomTag<short> tag, short value) => Add(DicomItemFactory.Create(tag, (int)value));
+
+    public void Set(DicomTag<uint> tag, uint value) => Add(DicomItemFactory.Create(tag, (int)value));
+
+    public void Set(DicomTag<long> tag, long value) => Add(DicomItemFactory.Create(tag, (int)value));
+
+    public void Set(DicomTag<float> tag, float value)
+    {
+        ushort group = tag.Group;
+        ushort element = tag.Element;
+        Add(new DicomFloatingPointSingle(group, element, [value]));
+    }
+
+    public void Set(DicomTag<double> tag, double value)
+    {
+        ushort group = tag.Group;
+        ushort element = tag.Element;
+        Add(new DicomFloatingPointDouble(group, element, [value]));
+    }
+
+    public void Set(DicomTag<PersonName> tag, PersonName value)
+    {
+        ushort group = tag.Group;
+        ushort element = tag.Element;
+        Add(new DicomPersonName(group, element, [value]));
+    }
+}

--- a/src/DcmSharp/DicomDataset.Set.Typed.cs
+++ b/src/DcmSharp/DicomDataset.Set.Typed.cs
@@ -16,11 +16,14 @@ public sealed partial record DicomDataset
 
     public void Set(DicomTag<ushort> tag, ushort value) => SetItem(DicomItemFactory.Create(tag, value));
 
-    public void Set(DicomTag<short> tag, short value) => SetItem(DicomItemFactory.Create(tag, (int)value));
+    public void Set(DicomTag<short> tag, short value)
+        => SetItem(new DicomSignedShort(tag.Group, tag.Element, [value]));
 
-    public void Set(DicomTag<uint> tag, uint value) => SetItem(DicomItemFactory.Create(tag, (int)value));
+    public void Set(DicomTag<uint> tag, uint value)
+        => SetItem(new DicomUnsignedLong(tag.Group, tag.Element, [value]));
 
-    public void Set(DicomTag<long> tag, long value) => SetItem(DicomItemFactory.Create(tag, (int)value));
+    public void Set(DicomTag<long> tag, long value)
+        => SetItem(new DicomSignedVeryLong(tag.Group, tag.Element, [value]));
 
     public void Set(DicomTag<float> tag, float value)
         => SetItem(new DicomFloatingPointSingle(tag.Group, tag.Element, [value]));

--- a/src/DcmSharp/DicomDataset.Set.Typed.cs
+++ b/src/DcmSharp/DicomDataset.Set.Typed.cs
@@ -2,32 +2,32 @@ namespace DcmSharp;
 
 public sealed partial record DicomDataset
 {
-    private void AddOrUpdate(IDicomItem item)
+    private void SetItem(IDicomItem item)
     {
         uint key = ((uint)item.Group << 16) | item.Element;
         _items[key] = item;
     }
 
-    public void Set(DicomTag<string> tag, string value) => AddOrUpdate(DicomItemFactory.Create(tag, value));
+    public void Set(DicomTag<string> tag, string value) => SetItem(DicomItemFactory.Create(tag, value));
 
-    public void Set(DicomTag<DateOnly> tag, DateOnly value) => AddOrUpdate(DicomItemFactory.Create(tag, value));
+    public void Set(DicomTag<DateOnly> tag, DateOnly value) => SetItem(DicomItemFactory.Create(tag, value));
 
-    public void Set(DicomTag<int> tag, int value) => AddOrUpdate(DicomItemFactory.Create(tag, value));
+    public void Set(DicomTag<int> tag, int value) => SetItem(DicomItemFactory.Create(tag, value));
 
-    public void Set(DicomTag<ushort> tag, ushort value) => AddOrUpdate(DicomItemFactory.Create(tag, value));
+    public void Set(DicomTag<ushort> tag, ushort value) => SetItem(DicomItemFactory.Create(tag, value));
 
-    public void Set(DicomTag<short> tag, short value) => AddOrUpdate(DicomItemFactory.Create(tag, (int)value));
+    public void Set(DicomTag<short> tag, short value) => SetItem(DicomItemFactory.Create(tag, (int)value));
 
-    public void Set(DicomTag<uint> tag, uint value) => AddOrUpdate(DicomItemFactory.Create(tag, (int)value));
+    public void Set(DicomTag<uint> tag, uint value) => SetItem(DicomItemFactory.Create(tag, (int)value));
 
-    public void Set(DicomTag<long> tag, long value) => AddOrUpdate(DicomItemFactory.Create(tag, (int)value));
+    public void Set(DicomTag<long> tag, long value) => SetItem(DicomItemFactory.Create(tag, (int)value));
 
     public void Set(DicomTag<float> tag, float value)
-        => AddOrUpdate(new DicomFloatingPointSingle(tag.Group, tag.Element, [value]));
+        => SetItem(new DicomFloatingPointSingle(tag.Group, tag.Element, [value]));
 
     public void Set(DicomTag<double> tag, double value)
-        => AddOrUpdate(new DicomFloatingPointDouble(tag.Group, tag.Element, [value]));
+        => SetItem(new DicomFloatingPointDouble(tag.Group, tag.Element, [value]));
 
     public void Set(DicomTag<PersonName> tag, PersonName value)
-        => AddOrUpdate(new DicomPersonName(tag.Group, tag.Element, [value]));
+        => SetItem(new DicomPersonName(tag.Group, tag.Element, [value]));
 }

--- a/src/DcmSharp/DicomDataset.Set.Typed.cs
+++ b/src/DcmSharp/DicomDataset.Set.Typed.cs
@@ -2,38 +2,32 @@ namespace DcmSharp;
 
 public sealed partial record DicomDataset
 {
-    public void Set(DicomTag<string> tag, string value) => Add(DicomItemFactory.Create(tag, value));
+    private void AddOrUpdate(IDicomItem item)
+    {
+        uint key = ((uint)item.Group << 16) | item.Element;
+        _items[key] = item;
+    }
 
-    public void Set(DicomTag<DateOnly> tag, DateOnly value) => Add(DicomItemFactory.Create(tag, value));
+    public void Set(DicomTag<string> tag, string value) => AddOrUpdate(DicomItemFactory.Create(tag, value));
 
-    public void Set(DicomTag<int> tag, int value) => Add(DicomItemFactory.Create(tag, value));
+    public void Set(DicomTag<DateOnly> tag, DateOnly value) => AddOrUpdate(DicomItemFactory.Create(tag, value));
 
-    public void Set(DicomTag<ushort> tag, ushort value) => Add(DicomItemFactory.Create(tag, value));
+    public void Set(DicomTag<int> tag, int value) => AddOrUpdate(DicomItemFactory.Create(tag, value));
 
-    public void Set(DicomTag<short> tag, short value) => Add(DicomItemFactory.Create(tag, (int)value));
+    public void Set(DicomTag<ushort> tag, ushort value) => AddOrUpdate(DicomItemFactory.Create(tag, value));
 
-    public void Set(DicomTag<uint> tag, uint value) => Add(DicomItemFactory.Create(tag, (int)value));
+    public void Set(DicomTag<short> tag, short value) => AddOrUpdate(DicomItemFactory.Create(tag, (int)value));
 
-    public void Set(DicomTag<long> tag, long value) => Add(DicomItemFactory.Create(tag, (int)value));
+    public void Set(DicomTag<uint> tag, uint value) => AddOrUpdate(DicomItemFactory.Create(tag, (int)value));
+
+    public void Set(DicomTag<long> tag, long value) => AddOrUpdate(DicomItemFactory.Create(tag, (int)value));
 
     public void Set(DicomTag<float> tag, float value)
-    {
-        ushort group = tag.Group;
-        ushort element = tag.Element;
-        Add(new DicomFloatingPointSingle(group, element, [value]));
-    }
+        => AddOrUpdate(new DicomFloatingPointSingle(tag.Group, tag.Element, [value]));
 
     public void Set(DicomTag<double> tag, double value)
-    {
-        ushort group = tag.Group;
-        ushort element = tag.Element;
-        Add(new DicomFloatingPointDouble(group, element, [value]));
-    }
+        => AddOrUpdate(new DicomFloatingPointDouble(tag.Group, tag.Element, [value]));
 
     public void Set(DicomTag<PersonName> tag, PersonName value)
-    {
-        ushort group = tag.Group;
-        ushort element = tag.Element;
-        Add(new DicomPersonName(group, element, [value]));
-    }
+        => AddOrUpdate(new DicomPersonName(tag.Group, tag.Element, [value]));
 }

--- a/src/DcmSharp/DicomDataset.TryGet.Typed.cs
+++ b/src/DcmSharp/DicomDataset.TryGet.Typed.cs
@@ -1,0 +1,193 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace DcmSharp;
+
+public sealed partial record DicomDataset
+{
+    public bool TryGet(DicomTag<string> tag, [NotNullWhen(true)] out string? value)
+        => TryGetString(tag, out value);
+
+    public bool TryGet(DicomTag<string[]> tag, [NotNullWhen(true)] out string[]? value)
+    {
+        // Delegate to TryGetString and wrap in array for now
+        if (TryGetString(tag, out string? single))
+        {
+            value = [single];
+            return true;
+        }
+        value = default;
+        return false;
+    }
+
+    public bool TryGet(DicomTag<DateOnly> tag, out DateOnly value)
+    {
+        if (!TryGet(tag, out IDicomItem? item))
+        {
+            value = default;
+            return false;
+        }
+
+        if (item is DicomDate { Value: { Length: > 0 } v })
+        {
+            value = v[0];
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public bool TryGet(DicomTag<DateTime> tag, out DateTime value)
+        => TryGetDateTime(tag, out value);
+
+    public bool TryGet(DicomTag<short> tag, out short value)
+    {
+        if (!TryGet(tag, out IDicomItem? item))
+        {
+            value = default;
+            return false;
+        }
+
+        if (item is DicomSignedShort { Value: { Length: > 0 } v })
+        {
+            value = v[0];
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public bool TryGet(DicomTag<ushort> tag, out ushort value)
+    {
+        if (!TryGet(tag, out IDicomItem? item))
+        {
+            value = default;
+            return false;
+        }
+
+        if (item is DicomUnsignedShort { Value: { Length: > 0 } v })
+        {
+            value = v[0];
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public bool TryGet(DicomTag<int> tag, out int value)
+    {
+        if (!TryGet(tag, out IDicomItem? item))
+        {
+            value = default;
+            return false;
+        }
+
+        if (item is DicomSignedLong { Value: { Length: > 0 } v })
+        {
+            value = v[0];
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public bool TryGet(DicomTag<uint> tag, out uint value)
+    {
+        if (!TryGet(tag, out IDicomItem? item))
+        {
+            value = default;
+            return false;
+        }
+
+        if (item is DicomUnsignedLong { Value: { Length: > 0 } v })
+        {
+            value = v[0];
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public bool TryGet(DicomTag<long> tag, out long value)
+        => TryGetLong(tag, out value);
+
+    public bool TryGet(DicomTag<ulong> tag, out ulong value)
+    {
+        if (!TryGet(tag, out IDicomItem? item))
+        {
+            value = default;
+            return false;
+        }
+
+        switch (item)
+        {
+            case DicomUnsignedLong { Value: { Length: > 0 } v }:
+                value = v[0];
+                return true;
+            case DicomUnsignedShort { Value: { Length: > 0 } v }:
+                value = v[0];
+                return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public bool TryGet(DicomTag<float> tag, out float value)
+    {
+        if (!TryGet(tag, out IDicomItem? item))
+        {
+            value = default;
+            return false;
+        }
+
+        if (item is DicomFloatingPointSingle { Value: { Length: > 0 } v })
+        {
+            value = v[0];
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public bool TryGet(DicomTag<double> tag, out double value)
+    {
+        if (!TryGet(tag, out IDicomItem? item))
+        {
+            value = default;
+            return false;
+        }
+
+        if (item is DicomFloatingPointDouble { Value: { Length: > 0 } v })
+        {
+            value = v[0];
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public bool TryGet(DicomTag<PersonName> tag, [NotNullWhen(true)] out PersonName? value)
+    {
+        if (!TryGet(tag, out IDicomItem? item))
+        {
+            value = default;
+            return false;
+        }
+
+        if (item is DicomPersonName { Value: { Length: > 0 } v })
+        {
+            value = v[0];
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/src/DcmSharp/DicomDataset.TryGet.Typed.cs
+++ b/src/DcmSharp/DicomDataset.TryGet.Typed.cs
@@ -9,12 +9,43 @@ public sealed partial record DicomDataset
 
     public bool TryGet(DicomTag<string[]> tag, [NotNullWhen(true)] out string[]? value)
     {
-        // Delegate to TryGetString and wrap in array for now
-        if (TryGetString(tag, out string? single))
+        if (!TryGet(tag, out IDicomItem? item))
         {
-            value = [single];
-            return true;
+            value = default;
+            return false;
         }
+
+        switch (item)
+        {
+            case DicomApplicationEntity { Value: { Length: > 0 } v }:
+                value = v;
+                return true;
+            case DicomAgeString { Value: { Length: > 0 } v }:
+                value = v;
+                return true;
+            case DicomCodeString { Value: { Length: > 0 } v }:
+                value = v;
+                return true;
+            case DicomDecimalString { Value: { Length: > 0 } v }:
+                value = v;
+                return true;
+            case DicomIntegerString { Value: { Length: > 0 } v }:
+                value = v;
+                return true;
+            case DicomLongString { Value: { Length: > 0 } v }:
+                value = v;
+                return true;
+            case DicomShortString { Value: { Length: > 0 } v }:
+                value = v;
+                return true;
+            case DicomUnlimitedCharacters { Value: { Length: > 0 } v }:
+                value = v;
+                return true;
+            case DicomUniqueIdentifier { Value: { Length: > 0 } v }:
+                value = v;
+                return true;
+        }
+
         value = default;
         return false;
     }
@@ -173,7 +204,7 @@ public sealed partial record DicomDataset
         return false;
     }
 
-    public bool TryGet(DicomTag<PersonName> tag, [NotNullWhen(true)] out PersonName? value)
+    public bool TryGet(DicomTag<PersonName> tag, out PersonName value)
     {
         if (!TryGet(tag, out IDicomItem? item))
         {

--- a/src/DcmSharp/DicomTag.TryParse.cs
+++ b/src/DcmSharp/DicomTag.TryParse.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 
 namespace DcmSharp;
 
-public sealed partial record DicomTag
+public partial record DicomTag
 {
     /// <summary>
     /// Parses a DICOM tag from a string in the following formats:

--- a/src/DcmSharp/DicomTag.cs
+++ b/src/DcmSharp/DicomTag.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// The definition of a DICOM tag
 /// </summary>
-public sealed partial record DicomTag(
+public partial record DicomTag(
     ushort Group,
     ushort Element,
     DicomVR ValueRepresentation,

--- a/src/DcmSharp/DicomTag{T}.cs
+++ b/src/DcmSharp/DicomTag{T}.cs
@@ -1,0 +1,15 @@
+namespace DcmSharp;
+
+/// <summary>
+/// A strongly-typed DICOM tag that encodes the CLR return type at compile time.
+/// This enables type-safe access to tag values without requiring the caller to know the VR.
+/// </summary>
+/// <typeparam name="T">The CLR type that this tag's value resolves to.</typeparam>
+public sealed record DicomTag<T>(
+    ushort Group,
+    ushort Element,
+    DicomVR ValueRepresentation,
+    DicomVR[] AdditionalValueRepresentations,
+    DicomVM ValueMultiplicity,
+    string Keyword,
+    string Name) : DicomTag(Group, Element, ValueRepresentation, AdditionalValueRepresentations, ValueMultiplicity, Keyword, Name);

--- a/src/DcmSharp/ReadOnlyDicomDataset.TryGet.Typed.cs
+++ b/src/DcmSharp/ReadOnlyDicomDataset.TryGet.Typed.cs
@@ -1,0 +1,103 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace DcmSharp;
+
+public readonly partial record struct ReadOnlyDicomDataset
+{
+    public bool TryGet(DicomTag<string> tag, [NotNullWhen(true)] out string? value)
+        => TryGetString(tag, out value);
+
+    public bool TryGet(DicomTag<string[]> tag, [NotNullWhen(true)] out string[]? value)
+        => TryGetStrings(tag, out value);
+
+    public bool TryGet(DicomTag<DateOnly> tag, out DateOnly value)
+        => TryGetDate(tag, out value);
+
+    public bool TryGet(DicomTag<DateOnly[]> tag, [NotNullWhen(true)] out DateOnly[]? value)
+        => TryGetDates(tag, out value);
+
+    public bool TryGet(DicomTag<TimeOnly> tag, out TimeOnly value)
+        => TryGetTime(tag, out value);
+
+    public bool TryGet(DicomTag<TimeOnly[]> tag, [NotNullWhen(true)] out TimeOnly[]? value)
+        => TryGetTimes(tag, out value);
+
+    public bool TryGet(DicomTag<DateTime> tag, out DateTime value)
+        => TryGetDateTime(tag, out value);
+
+    public bool TryGet(DicomTag<DateTime[]> tag, [NotNullWhen(true)] out DateTime[]? value)
+        => TryGetDateTimes(tag, out value);
+
+    public bool TryGet(DicomTag<short> tag, out short value)
+        => TryGetShort(tag, out value);
+
+    public bool TryGet(DicomTag<short[]> tag, [NotNullWhen(true)] out short[]? value)
+        => TryGetShorts(tag, out value);
+
+    public bool TryGet(DicomTag<ushort> tag, out ushort value)
+        => TryGetUShort(tag, out value);
+
+    public bool TryGet(DicomTag<ushort[]> tag, [NotNullWhen(true)] out ushort[]? value)
+        => TryGetUShorts(tag, out value);
+
+    public bool TryGet(DicomTag<int> tag, out int value)
+        => TryGetInt(tag, out value);
+
+    public bool TryGet(DicomTag<int[]> tag, [NotNullWhen(true)] out int[]? value)
+        => TryGetInts(tag, out value);
+
+    public bool TryGet(DicomTag<uint> tag, out uint value)
+        => TryGetUInt(tag, out value);
+
+    public bool TryGet(DicomTag<uint[]> tag, [NotNullWhen(true)] out uint[]? value)
+        => TryGetUInts(tag, out value);
+
+    public bool TryGet(DicomTag<long> tag, out long value)
+        => TryGetLong(tag, out value);
+
+    public bool TryGet(DicomTag<long[]> tag, [NotNullWhen(true)] out long[]? value)
+        => TryGetLongs(tag, out value);
+
+    public bool TryGet(DicomTag<ulong> tag, out ulong value)
+        => TryGetULong(tag, out value);
+
+    public bool TryGet(DicomTag<ulong[]> tag, [NotNullWhen(true)] out ulong[]? value)
+        => TryGetULongs(tag, out value);
+
+    public bool TryGet(DicomTag<float> tag, out float value)
+        => TryGetFloat(tag, out value);
+
+    public bool TryGet(DicomTag<float[]> tag, [NotNullWhen(true)] out float[]? value)
+        => TryGetFloats(tag, out value);
+
+    public bool TryGet(DicomTag<double> tag, out double value)
+        => TryGetDouble(tag, out value);
+
+    public bool TryGet(DicomTag<double[]> tag, [NotNullWhen(true)] out double[]? value)
+        => TryGetDoubles(tag, out value);
+
+    public bool TryGet(DicomTag<PersonName> tag, out PersonName value)
+        => TryGetPersonName(tag, out value);
+
+    public bool TryGet(DicomTag<PersonName[]> tag, [NotNullWhen(true)] out PersonName[]? value)
+    {
+        if (TryGetPersonNames(tag, out PersonName[] values))
+        {
+            value = values;
+            return true;
+        }
+        value = default;
+        return false;
+    }
+
+    public bool TryGet(DicomTag<ReadOnlyMemory<byte>> tag, [NotNullWhen(true)] out ReadOnlyMemory<byte>? value)
+    {
+        if (TryGetMemory(tag, out ReadOnlyMemory<byte>? mem, out _))
+        {
+            value = mem;
+            return true;
+        }
+        value = default;
+        return false;
+    }
+}

--- a/tests/DcmSharp.SourceGenerator.Tests/DicomTagsGeneratorTests.cs
+++ b/tests/DcmSharp.SourceGenerator.Tests/DicomTagsGeneratorTests.cs
@@ -10,10 +10,12 @@ public class TestsForDicomTagsGenerator
     {
         // Arrange
         var testCode = """
+                       using System;
+
                        /// <summary>
                        /// The definition of a DICOM tag
                        /// </summary>
-                       public sealed partial record DicomTag(
+                       public partial record DicomTag(
                            ushort Group,
                            ushort Element,
                            DicomVR ValueRepresentation,
@@ -27,6 +29,20 @@ public class TestsForDicomTagsGenerator
                                return $"({Group:x4},{Element:x4}) {Name}";
                            }
                        }
+
+                       /// <summary>
+                       /// A strongly-typed DICOM tag.
+                       /// </summary>
+                       public sealed record DicomTag<T>(
+                           ushort Group,
+                           ushort Element,
+                           DicomVR ValueRepresentation,
+                           DicomVR[] AdditionalValueRepresentations,
+                           DicomVM ValueMultiplicity,
+                           string Keyword,
+                           string Name) : DicomTag(Group, Element, ValueRepresentation, AdditionalValueRepresentations, ValueMultiplicity, Keyword, Name);
+
+                       public readonly record struct PersonName(string Value);
 
                        // <summary>
                        /// DICOM value multiplicity

--- a/tests/DcmSharp.Tests/TestsForTypedDicomTags.cs
+++ b/tests/DcmSharp.Tests/TestsForTypedDicomTags.cs
@@ -145,10 +145,10 @@ public sealed class TestsForTypedDicomTags
         var name = new PersonName("DOE", "JOHN", null, null, null, null, null, null, null);
         dataset.Set(DicomTags.PatientName, name);
 
-        dataset.TryGet(DicomTags.PatientName, out PersonName? value).Should().BeTrue();
+        dataset.TryGet(DicomTags.PatientName, out PersonName value).Should().BeTrue();
 
-        value!.Value.FamilyName.Should().Be("DOE");
-        value.Value.GivenName.Should().Be("JOHN");
+        value.FamilyName.Should().Be("DOE");
+        value.GivenName.Should().Be("JOHN");
     }
 
     [Fact]

--- a/tests/DcmSharp.Tests/TestsForTypedDicomTags.cs
+++ b/tests/DcmSharp.Tests/TestsForTypedDicomTags.cs
@@ -1,0 +1,176 @@
+using DcmSharp;
+using DcmSharp.Parser;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DcmSharp.Tests;
+
+[Collection(nameof(DicomParserCollection))]
+public sealed class TestsForTypedDicomTags
+{
+    private readonly IDicomParser _dicomParser;
+
+    public TestsForTypedDicomTags(DicomParserFixture fixture, ITestOutputHelper output)
+    {
+        fixture.OutputHelper = output;
+        _dicomParser = fixture.DicomParser;
+    }
+
+    [Fact]
+    public async Task TryGet_String_ShouldReturnValue_FromReadOnlyDataset()
+    {
+        var file = new FileInfo("./Dicom/ExplicitVR.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SOPInstanceUID, out var value).Should().BeTrue();
+
+        value.Should().Be("2.25.332838821141227624838581964210008219211");
+    }
+
+    [Fact]
+    public async Task TryGet_String_ShouldReturnFalse_WhenTagMissing_FromReadOnlyDataset()
+    {
+        var file = new FileInfo("./Dicom/ExplicitVR.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.InstitutionAddress, out string? _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TryGet_UShort_ShouldReturnValue_FromReadOnlyDataset()
+    {
+        var file = new FileInfo("./Dicom/ExplicitVR.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.Rows, out ushort value).Should().BeTrue();
+
+        value.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task TryGet_Date_ShouldReturnValue_FromReadOnlyDataset()
+    {
+        var file = new FileInfo("./Dicom/ExplicitVR.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.StudyDate, out DateOnly value).Should().BeTrue();
+
+        value.Year.Should().BeGreaterThan(2000);
+    }
+
+    [Fact]
+    public async Task TryGet_PersonName_ShouldReturnValue_FromReadOnlyDataset()
+    {
+        var file = new FileInfo("./Dicom/ExplicitVR.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.PatientName, out PersonName value).Should().BeTrue();
+
+        value.Should().NotBe(default(PersonName));
+    }
+
+    [Fact]
+    public void TryGet_String_ShouldReturnValue_FromMutableDataset()
+    {
+        var dataset = new DicomDataset();
+        dataset.Set(DicomTags.AccessionNumber, "ABC123");
+
+        dataset.TryGet(DicomTags.AccessionNumber, out var value).Should().BeTrue();
+
+        value.Should().Be("ABC123");
+    }
+
+    [Fact]
+    public void TryGet_UShort_ShouldReturnValue_FromMutableDataset()
+    {
+        var dataset = new DicomDataset();
+        dataset.Set(DicomTags.Rows, (ushort)512);
+
+        dataset.TryGet(DicomTags.Rows, out ushort value).Should().BeTrue();
+
+        value.Should().Be(512);
+    }
+
+    [Fact]
+    public void TryGet_Double_ShouldReturnValue_FromMutableDataset()
+    {
+        var dataset = new DicomDataset();
+        // Use a tag that's actually FD VM=1
+        var fdTag = new DicomTag<double>(0x0018, 0x9087, DicomVR.FD, [], DicomVM.VM_1, "DiffusionBValue", "Diffusion b-value");
+        dataset.Set(fdTag, 3.14);
+
+        dataset.TryGet(fdTag, out double value).Should().BeTrue();
+
+        value.Should().BeApproximately(3.14, 0.001);
+    }
+
+    [Fact]
+    public void TryGet_Float_ShouldReturnValue_FromMutableDataset()
+    {
+        var dataset = new DicomDataset();
+        // Use a tag that's actually FL VM=1
+        var flTag = new DicomTag<float>(0x0018, 0x1151, DicomVR.FL, [], DicomVM.VM_1, "XRayTubeCurrent", "X-Ray Tube Current");
+        dataset.Set(flTag, 2.5f);
+
+        dataset.TryGet(flTag, out float value).Should().BeTrue();
+
+        value.Should().BeApproximately(2.5f, 0.001f);
+    }
+
+    [Fact]
+    public void Set_ShouldOverwriteExistingValue()
+    {
+        var dataset = new DicomDataset();
+        dataset.Set(DicomTags.AccessionNumber, "OLD");
+        dataset.Set(DicomTags.AccessionNumber, "NEW");
+
+        dataset.TryGet(DicomTags.AccessionNumber, out var value).Should().BeTrue();
+
+        value.Should().Be("NEW");
+    }
+
+    [Fact]
+    public void TryGet_String_ShouldReturnFalse_WhenTagMissing_FromMutableDataset()
+    {
+        var dataset = new DicomDataset();
+
+        dataset.TryGet(DicomTags.AccessionNumber, out string? _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Set_PersonName_ShouldRoundTrip()
+    {
+        var dataset = new DicomDataset();
+        var name = new PersonName("DOE", "JOHN", null, null, null, null, null, null, null);
+        dataset.Set(DicomTags.PatientName, name);
+
+        dataset.TryGet(DicomTags.PatientName, out PersonName? value).Should().BeTrue();
+
+        value!.Value.FamilyName.Should().Be("DOE");
+        value.Value.GivenName.Should().Be("JOHN");
+    }
+
+    [Fact]
+    public void TypeSafety_TagTypeParameter_PreventsWrongAccess()
+    {
+        // This test verifies that DicomTags constants have the correct type parameter.
+        // If these assignments compile, type safety is working correctly.
+        DicomTag<string> stringTag = DicomTags.AccessionNumber;
+        DicomTag<ushort> ushortTag = DicomTags.Rows;
+        DicomTag<DateOnly> dateTag = DicomTags.StudyDate;
+        DicomTag<PersonName> pnTag = DicomTags.PatientName;
+
+        // All should be assignable to base DicomTag
+        DicomTag baseTag1 = stringTag;
+        DicomTag baseTag2 = ushortTag;
+        DicomTag baseTag3 = dateTag;
+        DicomTag baseTag4 = pnTag;
+
+        // Verify they carry the expected metadata
+        stringTag.ValueRepresentation.Should().Be(DicomVR.SH);
+        ushortTag.ValueRepresentation.Should().Be(DicomVR.US);
+        dateTag.ValueRepresentation.Should().Be(DicomVR.DA);
+        pnTag.ValueRepresentation.Should().Be(DicomVR.PN);
+    }
+}

--- a/tests/DcmSharp.Tests/TestsForTypedDicomTags.cs
+++ b/tests/DcmSharp.Tests/TestsForTypedDicomTags.cs
@@ -17,160 +17,542 @@ public sealed class TestsForTypedDicomTags
         _dicomParser = fixture.DicomParser;
     }
 
+    // ===========================
+    // ReadOnlyDicomDataset TryGet — scalar types from ExplicitVR.dcm
+    // ===========================
+
     [Fact]
-    public async Task TryGet_String_ShouldReturnValue_FromReadOnlyDataset()
+    public async Task ReadOnly_TryGet_String_SOPInstanceUID()
     {
         var file = new FileInfo("./Dicom/ExplicitVR.dcm");
         using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
 
-        dataset.TryGet(DicomTags.SOPInstanceUID, out var value).Should().BeTrue();
-
+        dataset.TryGet(DicomTags.SOPInstanceUID, out string? value).Should().BeTrue();
         value.Should().Be("2.25.332838821141227624838581964210008219211");
     }
 
     [Fact]
-    public async Task TryGet_String_ShouldReturnFalse_WhenTagMissing_FromReadOnlyDataset()
+    public async Task ReadOnly_TryGet_String_AccessionNumber()
     {
         var file = new FileInfo("./Dicom/ExplicitVR.dcm");
         using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
 
-        dataset.TryGet(DicomTags.InstitutionAddress, out string? _).Should().BeFalse();
+        dataset.TryGet(DicomTags.AccessionNumber, out string? value).Should().BeTrue();
+        value.Should().NotBeNull();
     }
 
     [Fact]
-    public async Task TryGet_UShort_ShouldReturnValue_FromReadOnlyDataset()
+    public async Task ReadOnly_TryGet_PersonName_PatientName()
+    {
+        var file = new FileInfo("./Dicom/ExplicitVR.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.PatientName, out PersonName value).Should().BeTrue();
+        value.Should().NotBe(default(PersonName));
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_UShort_Rows()
     {
         var file = new FileInfo("./Dicom/ExplicitVR.dcm");
         using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         dataset.TryGet(DicomTags.Rows, out ushort value).Should().BeTrue();
-
         value.Should().BeGreaterThan(0);
     }
 
     [Fact]
-    public async Task TryGet_Date_ShouldReturnValue_FromReadOnlyDataset()
+    public async Task ReadOnly_TryGet_UShort_Columns()
+    {
+        var file = new FileInfo("./Dicom/ExplicitVR.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.Columns, out ushort value).Should().BeTrue();
+        value.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_DateOnly_StudyDate()
     {
         var file = new FileInfo("./Dicom/ExplicitVR.dcm");
         using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         dataset.TryGet(DicomTags.StudyDate, out DateOnly value).Should().BeTrue();
-
-        value.Year.Should().BeGreaterThan(2000);
+        value.Should().NotBe(default);
     }
 
     [Fact]
-    public async Task TryGet_PersonName_ShouldReturnValue_FromReadOnlyDataset()
+    public async Task ReadOnly_TryGet_TimeOnly_StudyTime()
     {
         var file = new FileInfo("./Dicom/ExplicitVR.dcm");
         using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
 
-        dataset.TryGet(DicomTags.PatientName, out PersonName value).Should().BeTrue();
+        dataset.TryGet(DicomTags.StudyTime, out TimeOnly value).Should().BeTrue();
+        value.Should().NotBe(default);
+    }
 
-        value.Should().NotBe(default(PersonName));
+
+
+    // ===========================
+    // ReadOnlyDicomDataset TryGet — array types from SingleValues.dcm
+    // ===========================
+
+    [Fact]
+    public async Task ReadOnly_TryGet_StringArray_AE()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorAEValue, out string[]? value).Should().BeTrue();
+        value.Should().Contain("MODALITY1");
     }
 
     [Fact]
-    public void TryGet_String_ShouldReturnValue_FromMutableDataset()
+    public async Task ReadOnly_TryGet_StringArray_LO()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorLOValue, out string[]? value).Should().BeTrue();
+        value.Should().Contain("Medical Center A");
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_StringArray_SH()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorSHValue, out string[]? value).Should().BeTrue();
+        value.Should().Contain("CT123");
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_StringArray_UI()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorUIValue, out string[]? value).Should().BeTrue();
+        value.Should().Contain("1.2.3");
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_DateOnlyArray_DA()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorDAValue, out DateOnly[]? value).Should().BeTrue();
+        value.Should().Contain(DateOnly.Parse("2024-12-03"));
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_TimeOnlyArray_TM()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorTMValue, out TimeOnly[]? value).Should().BeTrue();
+        value.Should().Contain(TimeOnly.Parse("12:00:00"));
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_DateTimeArray_DT()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorDTValue, out DateTime[]? value).Should().BeTrue();
+        value.Should().Contain(DateTime.Parse("2024-12-03T12:00:00"));
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_ShortArray_SS()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorSSValue, out short[]? value).Should().BeTrue();
+        value.Should().Contain((short)-32768);
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_UShortArray_US()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorUSValue, out ushort[]? value).Should().BeTrue();
+        value.Should().Contain((ushort)1);
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_IntArray_SL()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorSLValue, out int[]? value).Should().BeTrue();
+        value.Should().Contain(-1);
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_UIntArray_UL()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorULValue, out uint[]? value).Should().BeTrue();
+        value.Should().Contain(4294967295u);
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_LongArray_SV()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorSVValue, out long[]? value).Should().BeTrue();
+        value.Should().Contain(9223372036854775807L);
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_ULongArray_UV()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorUVValue, out ulong[]? value).Should().BeTrue();
+        value.Should().Contain(18446744073709551615UL);
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_FloatArray_FL()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorFLValue, out float[]? value).Should().BeTrue();
+        value.Should().Contain(100.5f);
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_DoubleArray_FD()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorFDValue, out double[]? value).Should().BeTrue();
+        value.Should().Contain(-100.123);
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_PersonNameArray_PN()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.SelectorPNValue, out PersonName[]? value).Should().BeTrue();
+        value.Should().Contain(new PersonName("Dr", "Smith", null, null, null, null, null, null, null));
+    }
+
+    // ===========================
+    // ReadOnlyDicomDataset TryGet — missing tags return false
+    // ===========================
+
+    [Fact]
+    public async Task ReadOnly_TryGet_String_ReturnsFalse_WhenMissing()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        // Use a tag that definitely exists as DicomTag<string> but isn't in this file
+        dataset.TryGet(DicomTags.AccessionNumber, out string? _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_DateOnly_ReturnsFalse_WhenMissing()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.StudyDate, out DateOnly _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_UShort_ReturnsFalse_WhenMissing()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.Rows, out ushort _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_PersonName_ReturnsFalse_WhenMissing()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        dataset.TryGet(DicomTags.PatientName, out PersonName _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ReadOnly_TryGet_Memory_ReturnsFalse_WhenMissing()
+    {
+        var file = new FileInfo("./Dicom/SingleValues.dcm");
+        using var dataset = await _dicomParser.ParseReadOnlyAsync(file);
+
+        var obTag = new DicomTag<ReadOnlyMemory<byte>>(0x7FFF, 0x0001, DicomVR.OB, [], DicomVM.VM_1, "FakeTag", "Fake Tag");
+        dataset.TryGet(obTag, out ReadOnlyMemory<byte>? _).Should().BeFalse();
+    }
+
+    // ===========================
+    // DicomDataset Set + TryGet roundtrips — scalars
+    // ===========================
+
+    [Fact]
+    public void Mutable_Set_TryGet_String()
     {
         var dataset = new DicomDataset();
         dataset.Set(DicomTags.AccessionNumber, "ABC123");
 
-        dataset.TryGet(DicomTags.AccessionNumber, out var value).Should().BeTrue();
-
+        dataset.TryGet(DicomTags.AccessionNumber, out string? value).Should().BeTrue();
         value.Should().Be("ABC123");
     }
 
     [Fact]
-    public void TryGet_UShort_ShouldReturnValue_FromMutableDataset()
+    public void Mutable_Set_TryGet_DateOnly()
+    {
+        var dataset = new DicomDataset();
+        var date = new DateOnly(2024, 6, 15);
+        dataset.Set(DicomTags.StudyDate, date);
+
+        dataset.TryGet(DicomTags.StudyDate, out DateOnly value).Should().BeTrue();
+        value.Should().Be(date);
+    }
+
+    [Fact]
+    public void Mutable_Set_TryGet_Short()
+    {
+        var tag = new DicomTag<short>(0x0072, 0x0074, DicomVR.SS, [], DicomVM.VM_1, "SelectorSSValue", "Selector SS Value");
+        var dataset = new DicomDataset();
+        dataset.Set(tag, (short)-12345);
+
+        dataset.TryGet(tag, out short value).Should().BeTrue();
+        value.Should().Be(-12345);
+    }
+
+    [Fact]
+    public void Mutable_Set_TryGet_UShort()
     {
         var dataset = new DicomDataset();
         dataset.Set(DicomTags.Rows, (ushort)512);
 
         dataset.TryGet(DicomTags.Rows, out ushort value).Should().BeTrue();
-
         value.Should().Be(512);
     }
 
     [Fact]
-    public void TryGet_Double_ShouldReturnValue_FromMutableDataset()
+    public void Mutable_Set_TryGet_Int()
     {
+        var tag = new DicomTag<int>(0x0072, 0x0076, DicomVR.SL, [], DicomVM.VM_1, "SelectorSLValue", "Selector SL Value");
         var dataset = new DicomDataset();
-        // Use a tag that's actually FD VM=1
-        var fdTag = new DicomTag<double>(0x0018, 0x9087, DicomVR.FD, [], DicomVM.VM_1, "DiffusionBValue", "Diffusion b-value");
-        dataset.Set(fdTag, 3.14);
+        dataset.Set(tag, -999999);
 
-        dataset.TryGet(fdTag, out double value).Should().BeTrue();
-
-        value.Should().BeApproximately(3.14, 0.001);
+        dataset.TryGet(tag, out int value).Should().BeTrue();
+        value.Should().Be(-999999);
     }
 
     [Fact]
-    public void TryGet_Float_ShouldReturnValue_FromMutableDataset()
+    public void Mutable_Set_TryGet_UInt()
     {
+        var tag = new DicomTag<uint>(0x0072, 0x0078, DicomVR.UL, [], DicomVM.VM_1, "SelectorULValue", "Selector UL Value");
         var dataset = new DicomDataset();
-        // Use a tag that's actually FL VM=1
-        var flTag = new DicomTag<float>(0x0018, 0x1151, DicomVR.FL, [], DicomVM.VM_1, "XRayTubeCurrent", "X-Ray Tube Current");
-        dataset.Set(flTag, 2.5f);
+        dataset.Set(tag, 4294967295u);
 
-        dataset.TryGet(flTag, out float value).Should().BeTrue();
-
-        value.Should().BeApproximately(2.5f, 0.001f);
+        dataset.TryGet(tag, out uint value).Should().BeTrue();
+        value.Should().Be(4294967295u);
     }
 
     [Fact]
-    public void Set_ShouldOverwriteExistingValue()
+    public void Mutable_Set_TryGet_Long()
+    {
+        var tag = new DicomTag<long>(0x0072, 0x007A, DicomVR.SV, [], DicomVM.VM_1, "SelectorSVValue", "Selector SV Value");
+        var dataset = new DicomDataset();
+        dataset.Set(tag, long.MaxValue);
+
+        dataset.TryGet(tag, out long value).Should().BeTrue();
+        value.Should().Be(long.MaxValue);
+    }
+
+    [Fact]
+    public void Mutable_Set_TryGet_Float()
+    {
+        var tag = new DicomTag<float>(0x0072, 0x006E, DicomVR.FL, [], DicomVM.VM_1, "SelectorFLValue", "Selector FL Value");
+        var dataset = new DicomDataset();
+        dataset.Set(tag, 3.14f);
+
+        dataset.TryGet(tag, out float value).Should().BeTrue();
+        value.Should().Be(3.14f);
+    }
+
+    [Fact]
+    public void Mutable_Set_TryGet_Double()
+    {
+        var tag = new DicomTag<double>(0x0072, 0x0070, DicomVR.FD, [], DicomVM.VM_1, "SelectorFDValue", "Selector FD Value");
+        var dataset = new DicomDataset();
+        dataset.Set(tag, -100.123);
+
+        dataset.TryGet(tag, out double value).Should().BeTrue();
+        value.Should().Be(-100.123);
+    }
+
+    [Fact]
+    public void Mutable_Set_TryGet_PersonName()
+    {
+        var dataset = new DicomDataset();
+        var name = new PersonName("DOE", "JOHN", "M", "DR", "JR", null, null, null, null);
+        dataset.Set(DicomTags.PatientName, name);
+
+        dataset.TryGet(DicomTags.PatientName, out PersonName value).Should().BeTrue();
+        value.FamilyName.Should().Be("DOE");
+        value.GivenName.Should().Be("JOHN");
+        value.MiddleName.Should().Be("M");
+        value.NamePrefix.Should().Be("DR");
+        value.NameSuffix.Should().Be("JR");
+    }
+
+    // ===========================
+    // DicomDataset Set overwrite behavior (upsert)
+    // ===========================
+
+    [Fact]
+    public void Mutable_Set_OverwritesExistingString()
     {
         var dataset = new DicomDataset();
         dataset.Set(DicomTags.AccessionNumber, "OLD");
         dataset.Set(DicomTags.AccessionNumber, "NEW");
 
-        dataset.TryGet(DicomTags.AccessionNumber, out var value).Should().BeTrue();
-
+        dataset.TryGet(DicomTags.AccessionNumber, out string? value).Should().BeTrue();
         value.Should().Be("NEW");
     }
 
     [Fact]
-    public void TryGet_String_ShouldReturnFalse_WhenTagMissing_FromMutableDataset()
+    public void Mutable_Set_OverwritesExistingUShort()
     {
         var dataset = new DicomDataset();
+        dataset.Set(DicomTags.Rows, (ushort)100);
+        dataset.Set(DicomTags.Rows, (ushort)200);
 
+        dataset.TryGet(DicomTags.Rows, out ushort value).Should().BeTrue();
+        value.Should().Be(200);
+    }
+
+    [Fact]
+    public void Mutable_Set_OverwritesExistingPersonName()
+    {
+        var dataset = new DicomDataset();
+        dataset.Set(DicomTags.PatientName, new PersonName("OLD", null, null, null, null, null, null, null, null));
+        dataset.Set(DicomTags.PatientName, new PersonName("NEW", null, null, null, null, null, null, null, null));
+
+        dataset.TryGet(DicomTags.PatientName, out PersonName value).Should().BeTrue();
+        value.FamilyName.Should().Be("NEW");
+    }
+
+    // ===========================
+    // DicomDataset TryGet — missing tags return false
+    // ===========================
+
+    [Fact]
+    public void Mutable_TryGet_String_ReturnsFalse_WhenMissing()
+    {
+        var dataset = new DicomDataset();
         dataset.TryGet(DicomTags.AccessionNumber, out string? _).Should().BeFalse();
     }
 
     [Fact]
-    public void Set_PersonName_ShouldRoundTrip()
+    public void Mutable_TryGet_UShort_ReturnsFalse_WhenMissing()
     {
         var dataset = new DicomDataset();
-        var name = new PersonName("DOE", "JOHN", null, null, null, null, null, null, null);
-        dataset.Set(DicomTags.PatientName, name);
-
-        dataset.TryGet(DicomTags.PatientName, out PersonName value).Should().BeTrue();
-
-        value.FamilyName.Should().Be("DOE");
-        value.GivenName.Should().Be("JOHN");
+        dataset.TryGet(DicomTags.Rows, out ushort _).Should().BeFalse();
     }
 
     [Fact]
-    public void TypeSafety_TagTypeParameter_PreventsWrongAccess()
+    public void Mutable_TryGet_DateOnly_ReturnsFalse_WhenMissing()
     {
-        // This test verifies that DicomTags constants have the correct type parameter.
-        // If these assignments compile, type safety is working correctly.
+        var dataset = new DicomDataset();
+        dataset.TryGet(DicomTags.StudyDate, out DateOnly _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Mutable_TryGet_Double_ReturnsFalse_WhenMissing()
+    {
+        var tag = new DicomTag<double>(0x0072, 0x0070, DicomVR.FD, [], DicomVM.VM_1, "SelectorFDValue", "Selector FD Value");
+        var dataset = new DicomDataset();
+        dataset.TryGet(tag, out double _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Mutable_TryGet_PersonName_ReturnsFalse_WhenMissing()
+    {
+        var dataset = new DicomDataset();
+        dataset.TryGet(DicomTags.PatientName, out PersonName _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Mutable_TryGet_Long_ReturnsFalse_WhenMissing()
+    {
+        var tag = new DicomTag<long>(0x0072, 0x007A, DicomVR.SV, [], DicomVM.VM_1, "SelectorSVValue", "Selector SV Value");
+        var dataset = new DicomDataset();
+        dataset.TryGet(tag, out long _).Should().BeFalse();
+    }
+
+    // ===========================
+    // Type safety — compile-time guarantees
+    // ===========================
+
+    [Fact]
+    public void TypeSafety_GeneratedTags_HaveCorrectTypeParameter()
+    {
         DicomTag<string> stringTag = DicomTags.AccessionNumber;
         DicomTag<ushort> ushortTag = DicomTags.Rows;
         DicomTag<DateOnly> dateTag = DicomTags.StudyDate;
         DicomTag<PersonName> pnTag = DicomTags.PatientName;
 
-        // All should be assignable to base DicomTag
-        DicomTag baseTag1 = stringTag;
-        DicomTag baseTag2 = ushortTag;
-        DicomTag baseTag3 = dateTag;
-        DicomTag baseTag4 = pnTag;
-
-        // Verify they carry the expected metadata
         stringTag.ValueRepresentation.Should().Be(DicomVR.SH);
         ushortTag.ValueRepresentation.Should().Be(DicomVR.US);
         dateTag.ValueRepresentation.Should().Be(DicomVR.DA);
         pnTag.ValueRepresentation.Should().Be(DicomVR.PN);
+    }
+
+    [Fact]
+    public void TypeSafety_TypedTag_IsAssignableToBaseTag()
+    {
+        DicomTag<string> typed = DicomTags.AccessionNumber;
+        DicomTag untyped = typed;
+
+        untyped.Keyword.Should().Be("AccessionNumber");
+        untyped.Group.Should().Be(0x0008);
+        untyped.Element.Should().Be(0x0050);
+    }
+
+    [Fact]
+    public void TypeSafety_MultiVR_Tags_RemainUntyped()
+    {
+        DicomTag tag = DicomTags.SmallestImagePixelValue;
+        tag.AdditionalValueRepresentations.Should().NotBeEmpty();
+        tag.Should().NotBeOfType<DicomTag<ushort>>();
+        tag.Should().NotBeOfType<DicomTag<short>>();
+    }
+
+    [Fact]
+    public void TypeSafety_ArrayTypedTag_IsCorrect()
+    {
+        DicomTag<string[]> arrayTag = DicomTags.SelectorAEValue;
+        DicomTag untyped = arrayTag;
+
+        untyped.ValueRepresentation.Should().Be(DicomVR.AE);
     }
 }


### PR DESCRIPTION
Introduces DicomTag<T>, a generic subtype of DicomTag that encodes the CLR return type at compile time. Enables type-safe TryGet/Set without knowing the VR. All 2042 tests pass.