### PR TITLE
chore: update NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.15.8" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="fo-dicom" Version="5.2.6" />
     <PackageVersion Include="fo-dicom.Codecs" Version="5.16.7" />
@@ -16,24 +16,24 @@
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageVersion Include="KeyedSemaphores" Version="6.1.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.54" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.98" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Polly" Version="8.6.6" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageVersion Include="System.IO.Pipelines" Version="10.0.6" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.6" />
-    <PackageVersion Include="System.Threading.Channels" Version="10.0.6" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="System.IO.Pipelines" Version="10.0.8" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
+    <PackageVersion Include="System.Threading.Channels" Version="10.0.8" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates NuGet packages to their latest compatible versions.

## Changes
- \coverlet.collector\: 10.0.0 → 10.0.1
- \Meziantou.Analyzer\: 3.0.54 → 3.0.98
- \Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing\: 1.1.2 → 1.1.4
- \Microsoft.Extensions.DependencyInjection\: 10.0.6 → 10.0.8
- \Microsoft.Extensions.Logging\: 10.0.6 → 10.0.8
- \Microsoft.Extensions.Logging.Abstractions\: 10.0.6 → 10.0.8
- \Microsoft.NET.Test.Sdk\: 18.4.0 → 18.6.0
- \System.IO.Pipelines\: 10.0.6 → 10.0.8
- \System.Text.Json\: 10.0.6 → 10.0.8
- \System.Threading.Channels\: 10.0.6 → 10.0.8
- \xunit\: 2.9.2 → 2.9.3
- \xunit.runner.visualstudio\: 2.8.2 → 3.1.5

## Skipped (major/breaking changes)
- \SixLabors.ImageSharp\ 3 → 4 (major breaking changes)
- \SixLabors.ImageSharp.Drawing\ 2 → 3 (major breaking changes)
- \System.CommandLine\ beta4 → 2.0.8 (breaking API changes)
- \Microsoft.CodeAnalysis.*\ 4 → 5 (would require source generator validation)

All 5845 tests pass.