### PR TITLE
chore: remove FluentAssertions and migrate to xUnit assertions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,6 @@
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.15.8" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="fo-dicom" Version="5.2.6" />
     <PackageVersion Include="fo-dicom.Codecs" Version="5.16.7" />
     <PackageVersion Include="fo-dicom.Imaging.ImageSharp" Version="5.2.6" />

--- a/tests/DcmAnonymize.Tests/DcmAnonymize.Tests.csproj
+++ b/tests/DcmAnonymize.Tests/DcmAnonymize.Tests.csproj
@@ -4,7 +4,6 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/DcmAnonymize.Tests/Patient/TestsForNationalNumberGenerator.cs
+++ b/tests/DcmAnonymize.Tests/Patient/TestsForNationalNumberGenerator.cs
@@ -1,5 +1,4 @@
 using DcmAnonymize.Patient;
-using FluentAssertions;
 using Xunit;
 
 namespace DcmAnonymize.Tests.Patient;
@@ -32,11 +31,11 @@ public class TestsForNationalNumberGenerator
         var modulo = int.Parse(nationalNumber.Substring(9, 2));
         var combined = long.Parse(nationalNumber.Substring(0, 9));
 
-        year.Should().Be(94);
-        month.Should().Be(12);
-        day.Should().Be(5);
-        (index % 2).Should().Be(1); // Male should produce an odd index
-        modulo.Should().Be((int)(97 - combined % 97));
+        Assert.Equal(94, year);
+        Assert.Equal(12, month);
+        Assert.Equal(5, day);
+        Assert.Equal(1, (index % 2)); // Male should produce an odd index
+        Assert.Equal((int)(97 - combined % 97), modulo);
     }
 
     [Fact]
@@ -57,11 +56,11 @@ public class TestsForNationalNumberGenerator
         var modulo = int.Parse(nationalNumber.Substring(9, 2));
         var combined = long.Parse(nationalNumber.Substring(0, 9));
 
-        year.Should().Be(94);
-        month.Should().Be(12);
-        day.Should().Be(5);
-        (index % 2).Should().Be(0); // Female should produce an even index
-        modulo.Should().Be((int)(97 - combined % 97));
+        Assert.Equal(94, year);
+        Assert.Equal(12, month);
+        Assert.Equal(5, day);
+        Assert.Equal(0, (index % 2)); // Female should produce an even index
+        Assert.Equal((int)(97 - combined % 97), modulo);
     }
 
     [Fact]
@@ -82,10 +81,10 @@ public class TestsForNationalNumberGenerator
         var modulo = int.Parse(nationalNumber.Substring(9, 2));
         var combined = long.Parse("2" + nationalNumber.Substring(0, 9));
 
-        year.Should().Be(1);
-        month.Should().Be(12);
-        day.Should().Be(5);
-        (index % 2).Should().Be(1); // Male should produce an odd index
-        modulo.Should().Be((int)(97 - combined % 97));
+        Assert.Equal(1, year);
+        Assert.Equal(12, month);
+        Assert.Equal(5, day);
+        Assert.Equal(1, (index % 2)); // Male should produce an odd index
+        Assert.Equal((int)(97 - combined % 97), modulo);
     }
 }

--- a/tests/DcmAnonymize.Tests/TestsForDicomAnonymizer.cs
+++ b/tests/DcmAnonymize.Tests/TestsForDicomAnonymizer.cs
@@ -9,7 +9,6 @@ using DcmAnonymize.Study;
 using FellowOakDicom;
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.NativeCodec;
-using FluentAssertions;
 using Xunit;
 
 namespace DcmAnonymize.Tests;
@@ -94,11 +93,11 @@ public class TestsForDicomAnonymizer
         await _anonymizer.AnonymizeAsync(metaInfo, dicomDataSet, _options);
 
         // Assert
-        dicomDataSet.Contains(DicomTag.PatientName).Should().BeTrue();
-        dicomDataSet.GetSingleValue<string>(DicomTag.PatientName).Should().NotBe("Bar^Foo");
-        dicomDataSet.GetSingleValue<string>(DicomTag.StudyInstanceUID).Should().NotBe("1");
-        dicomDataSet.GetSingleValue<string>(DicomTag.SeriesInstanceUID).Should().NotBe("1.1");
-        dicomDataSet.GetSingleValue<string>(DicomTag.SOPInstanceUID).Should().NotBe("1.1.1");
+        Assert.True(dicomDataSet.Contains(DicomTag.PatientName));
+        Assert.NotEqual("Bar^Foo", dicomDataSet.GetSingleValue<string>(DicomTag.PatientName));
+        Assert.NotEqual("1", dicomDataSet.GetSingleValue<string>(DicomTag.StudyInstanceUID));
+        Assert.NotEqual("1.1", dicomDataSet.GetSingleValue<string>(DicomTag.SeriesInstanceUID));
+        Assert.NotEqual("1.1.1", dicomDataSet.GetSingleValue<string>(DicomTag.SOPInstanceUID));
     }
 
     [Fact]
@@ -129,9 +128,9 @@ public class TestsForDicomAnonymizer
         // Assert
         var patientName1 = dicomDataSet1.GetSingleValue<string>(DicomTag.PatientName);
         var patientName2 = dicomDataSet2.GetSingleValue<string>(DicomTag.PatientName);
-        patientName1.Should().NotBe("Bar^Foo");
-        patientName2.Should().NotBe("Bar^Foo");
-        patientName1.Should().Be(patientName2);
+        Assert.NotEqual("Bar^Foo", patientName1);
+        Assert.NotEqual("Bar^Foo", patientName2);
+        Assert.Equal(patientName2, patientName1);
     }
 
     [Fact]
@@ -181,11 +180,11 @@ public class TestsForDicomAnonymizer
         var orderNumber3 = dicomDataSet3.GetSingleValue<string>(
             DicomTag.PlacerOrderNumberImagingServiceRequest
         );
-        orderNumber1.Should().NotBe("ORDER1");
-        orderNumber2.Should().NotBe("ORDER1");
-        orderNumber3.Should().NotBe("ORDER2");
-        orderNumber1.Should().Be(orderNumber2);
-        orderNumber3.Should().NotBe(orderNumber1);
+        Assert.NotEqual("ORDER1", orderNumber1);
+        Assert.NotEqual("ORDER1", orderNumber2);
+        Assert.NotEqual("ORDER2", orderNumber3);
+        Assert.Equal(orderNumber2, orderNumber1);
+        Assert.NotEqual(orderNumber1, orderNumber3);
     }
 
     [Fact]
@@ -216,9 +215,9 @@ public class TestsForDicomAnonymizer
         // Assert
         var studyInstanceUID1 = dicomDataSet1.GetSingleValue<string>(DicomTag.StudyInstanceUID);
         var studyInstanceUID2 = dicomDataSet2.GetSingleValue<string>(DicomTag.StudyInstanceUID);
-        studyInstanceUID1.Should().NotBe("1");
-        studyInstanceUID2.Should().NotBe("1");
-        studyInstanceUID1.Should().Be(studyInstanceUID2);
+        Assert.NotEqual("1", studyInstanceUID1);
+        Assert.NotEqual("1", studyInstanceUID2);
+        Assert.Equal(studyInstanceUID2, studyInstanceUID1);
     }
 
     [Fact]
@@ -249,9 +248,9 @@ public class TestsForDicomAnonymizer
         // Assert
         var seriesInstanceUID1 = dicomDataSet1.GetSingleValue<string>(DicomTag.SeriesInstanceUID);
         var seriesInstanceUID2 = dicomDataSet2.GetSingleValue<string>(DicomTag.SeriesInstanceUID);
-        seriesInstanceUID1.Should().NotBe("1");
-        seriesInstanceUID2.Should().NotBe("1");
-        seriesInstanceUID1.Should().Be(seriesInstanceUID2);
+        Assert.NotEqual("1", seriesInstanceUID1);
+        Assert.NotEqual("1", seriesInstanceUID2);
+        Assert.Equal(seriesInstanceUID2, seriesInstanceUID1);
     }
 
     [Fact]
@@ -282,9 +281,9 @@ public class TestsForDicomAnonymizer
         // Assert
         var sopInstanceUID1 = dicomDataSet1.GetSingleValue<string>(DicomTag.SOPInstanceUID);
         var sopInstanceUID2 = dicomDataSet2.GetSingleValue<string>(DicomTag.SOPInstanceUID);
-        sopInstanceUID1.Should().NotBe("1.1.1");
-        sopInstanceUID2.Should().NotBe("1.1.1");
-        sopInstanceUID1.Should().Be(sopInstanceUID2);
+        Assert.NotEqual("1.1.1", sopInstanceUID1);
+        Assert.NotEqual("1.1.1", sopInstanceUID2);
+        Assert.Equal(sopInstanceUID2, sopInstanceUID1);
     }
 
     [Fact]
@@ -327,9 +326,9 @@ public class TestsForDicomAnonymizer
             .GetSingleValue<string>(DicomTag.ReferencedSOPInstanceUID);
 
         // Ensure our test data is correct
-        sopInstanceUID.Should().NotBeNullOrEmpty();
-        firstReferencedSopInstanceUID.Should().NotBeNullOrEmpty();
-        firstReferencedSopInstanceUID.Should().Be(sopInstanceUID);
+        Assert.True((sopInstanceUID)?.Any());
+        Assert.True((firstReferencedSopInstanceUID)?.Any());
+        Assert.Equal(sopInstanceUID, firstReferencedSopInstanceUID);
 
         // Act
         await _anonymizer.AnonymizeAsync(dicomFile1.FileMetaInfo, dicomFile1.Dataset, _options);
@@ -351,15 +350,15 @@ public class TestsForDicomAnonymizer
             .GetSingleValue<string>(DicomTag.ReferencedSOPInstanceUID);
 
         // Ensure data is still present
-        sopInstanceUID2.Should().NotBeNullOrEmpty();
-        firstReferencedSopInstanceUID2.Should().NotBeNullOrEmpty();
+        Assert.True((sopInstanceUID2)?.Any());
+        Assert.True((firstReferencedSopInstanceUID2)?.Any());
 
         // Ensure data is anonymized
-        sopInstanceUID.Should().NotBe(sopInstanceUID2);
-        firstReferencedSopInstanceUID.Should().NotBe(firstReferencedSopInstanceUID2);
+        Assert.NotEqual(sopInstanceUID2, sopInstanceUID);
+        Assert.NotEqual(firstReferencedSopInstanceUID2, firstReferencedSopInstanceUID);
 
         // Ensure referential integrity is retained
-        sopInstanceUID2.Should().Be(firstReferencedSopInstanceUID2);
+        Assert.Equal(firstReferencedSopInstanceUID2, sopInstanceUID2);
     }
 
     [Theory]
@@ -395,9 +394,9 @@ public class TestsForDicomAnonymizer
         await _anonymizer.AnonymizeAsync(metaInfo, dataSet, _options);
 
         // Assert
-        originalDataset.Contains(tag).Should().BeTrue();
-        dataSet.Contains(tag).Should().BeFalse();
-        dataSet.Contains(DicomTag.PatientName).Should().BeTrue();
+        Assert.True(originalDataset.Contains(tag));
+        Assert.False(dataSet.Contains(tag));
+        Assert.True(dataSet.Contains(DicomTag.PatientName));
     }
 
     [Theory]
@@ -434,11 +433,14 @@ public class TestsForDicomAnonymizer
         );
 
         // Assert
-        originalDataset1.GetSingleValue<DicomUID>(tag).Should().Be(originalUID);
-        originalDataset2.GetSingleValue<DicomUID>(tag).Should().Be(originalUID);
-        dataSet1.GetSingleValue<DicomUID>(tag).Should().NotBe(originalUID);
-        dataSet2.GetSingleValue<DicomUID>(tag).Should().NotBe(originalUID);
-        dataSet1.GetSingleValue<DicomUID>(tag).Should().Be(dataSet2.GetSingleValue<DicomUID>(tag));
+        Assert.Equal(originalUID, originalDataset1.GetSingleValue<DicomUID>(tag));
+        Assert.Equal(originalUID, originalDataset2.GetSingleValue<DicomUID>(tag));
+        Assert.NotEqual(originalUID, dataSet1.GetSingleValue<DicomUID>(tag));
+        Assert.NotEqual(originalUID, dataSet2.GetSingleValue<DicomUID>(tag));
+        Assert.Equal(
+            dataSet2.GetSingleValue<DicomUID>(tag),
+            dataSet1.GetSingleValue<DicomUID>(tag)
+        );
     }
 
     [Theory]
@@ -490,25 +492,25 @@ public class TestsForDicomAnonymizer
         await _anonymizer.AnonymizeAsync(metaInfo, dataSet, _options);
 
         // Assert
-        originalDataset.Contains(tag).Should().BeTrue();
-        dataSet.Contains(tag).Should().BeTrue();
+        Assert.True(originalDataset.Contains(tag));
+        Assert.True(dataSet.Contains(tag));
         if (valueRepresentation == DicomVR.SQ)
         {
-            dataSet.GetSequence(tag).ToList().Should().HaveCount(1);
+            Assert.Single(dataSet.GetSequence(tag).ToList() ?? []);
         }
         else if (valueRepresentation == DicomVR.OB || valueRepresentation == DicomVR.UN)
         {
-            dataSet.GetValues<byte>(tag).Should().BeEmpty();
+            Assert.Empty(dataSet.GetValues<byte>(tag) ?? []);
         }
         else if (valueRepresentation == DicomVR.PN)
         {
             var personName = dataSet.GetDicomItem<DicomPersonName>(tag);
-            personName.First.Should().NotBeEmpty();
-            personName.Last.Should().NotBeEmpty();
+            Assert.NotEmpty(personName.First);
+            Assert.NotEmpty(personName.Last);
         }
         else
         {
-            dataSet.GetString(tag).Should().Be(string.Empty);
+            Assert.Equal(string.Empty, dataSet.GetString(tag));
         }
     }
 
@@ -538,7 +540,7 @@ public class TestsForDicomAnonymizer
         var dicomImage = new DicomImage(dicomDataSet);
         using var image = dicomImage.RenderImage();
         var color = image.GetPixel(700, 700);
-        color.Should().Be(Color32.Black);
+        Assert.Equal(Color32.Black, color);
     }
 
     [Fact]
@@ -569,7 +571,7 @@ public class TestsForDicomAnonymizer
         {
             using var image = dicomImage.RenderImage(frame);
             var color = image.GetPixel(100, 100);
-            color.Should().Be(Color32.Black);
+            Assert.Equal(Color32.Black, color);
         }
     }
 
@@ -618,10 +620,10 @@ public class TestsForDicomAnonymizer
             var anonymizedAccessionNumber = dicomDataSet.GetSingleValue<string>(
                 DicomTag.AccessionNumber
             );
-            anonymizedStudyInstanceUID.Should().NotBe(originalStudyInstanceUID);
-            anonymizedSeriesInstanceUID.Should().NotBe(originalSeriesInstanceUID);
-            anonymizedSopInstanceUID.Should().NotBe(originalSopInstanceUID);
-            anonymizedAccessionNumber.Should().NotBe(originalAccessionNumber);
+            Assert.NotEqual(originalStudyInstanceUID, anonymizedStudyInstanceUID);
+            Assert.NotEqual(originalSeriesInstanceUID, anonymizedSeriesInstanceUID);
+            Assert.NotEqual(originalSopInstanceUID, anonymizedSopInstanceUID);
+            Assert.NotEqual(originalAccessionNumber, anonymizedAccessionNumber);
         }
     }
 }

--- a/tests/DcmFind.Tests/DcmFind.Tests.csproj
+++ b/tests/DcmFind.Tests/DcmFind.Tests.csproj
@@ -4,7 +4,6 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/DcmFind.Tests/TestsForDcmFind.cs
+++ b/tests/DcmFind.Tests/TestsForDcmFind.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using FluentAssertions;
 using Spectre.Console;
 using Xunit;
 using Xunit.Abstractions;
@@ -63,7 +62,7 @@ public class TestsForDcmFind : IDisposable
                 Environment.NewLine,
                 StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
             );
-        actual.Should().BeEquivalentTo(expected, c => c.WithoutStrictOrdering());
+        Assert.Equivalent(expected, actual);
         Assert.Equal(0, statusCode);
     }
 
@@ -85,7 +84,7 @@ public class TestsForDcmFind : IDisposable
                 Environment.NewLine,
                 StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
             );
-        actual.Should().BeEquivalentTo(expected, c => c.WithoutStrictOrdering());
+        Assert.Equivalent(expected, actual);
         Assert.Equal(0, statusCode);
     }
 
@@ -113,7 +112,7 @@ public class TestsForDcmFind : IDisposable
                 Environment.NewLine,
                 StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
             );
-        actual.Should().BeEquivalentTo(expected, c => c.WithoutStrictOrdering());
+        Assert.Equivalent(expected, actual);
         Assert.Equal(0, statusCode);
     }
 
@@ -143,7 +142,7 @@ public class TestsForDcmFind : IDisposable
                 Environment.NewLine,
                 StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
             );
-        actual.Should().BeEquivalentTo(expected, c => c.WithoutStrictOrdering());
+        Assert.Equivalent(expected, actual);
         Assert.Equal(0, statusCode);
     }
 }

--- a/tests/DcmFind.Tests/TestsForDicomTagParser.cs
+++ b/tests/DcmFind.Tests/TestsForDicomTagParser.cs
@@ -1,5 +1,4 @@
 using DcmSharp;
-using FluentAssertions;
 using Xunit;
 
 namespace DcmFind.Tests;
@@ -10,20 +9,20 @@ public class TestsForDicomTagParser
     [Fact]
     public void ShouldParseTagByGroupAndElement()
     {
-        DicomTagParser.TryParse("(0008,0050)", out var dicomTag).Should().BeTrue();
-        dicomTag.Should().Be(DicomTags.AccessionNumber);
+        Assert.True(DicomTagParser.TryParse("(0008,0050)", out var dicomTag));
+        Assert.Equal(DicomTags.AccessionNumber, dicomTag);
     }
 
     [Fact]
     public void ShouldParseTagByName()
     {
-        DicomTagParser.TryParse("AccessionNumber", out var dicomTag).Should().BeTrue();
-        dicomTag.Should().Be(DicomTags.AccessionNumber);
+        Assert.True(DicomTagParser.TryParse("AccessionNumber", out var dicomTag));
+        Assert.Equal(DicomTags.AccessionNumber, dicomTag);
     }
 
     [Fact]
     public void ShouldNotParseUnknownTag()
     {
-        DicomTagParser.TryParse("Banana", out _).Should().BeFalse();
+        Assert.False(DicomTagParser.TryParse("Banana", out _));
     }
 }

--- a/tests/DcmFind.Tests/TestsForQuery.cs
+++ b/tests/DcmFind.Tests/TestsForQuery.cs
@@ -1,5 +1,4 @@
 ﻿using DcmSharp;
-using FluentAssertions;
 using Xunit;
 
 namespace DcmFind.Tests;
@@ -24,7 +23,7 @@ public class TestsForQuery
         {
             var query = new EqualsQuery(DicomTags.AccessionNumber, "Pineapple");
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -32,7 +31,7 @@ public class TestsForQuery
         {
             var query = new EqualsQuery(DicomTags.AccessionNumber, "Pineapple2");
 
-            query.Matches(_dicomDataset).Should().BeFalse();
+            Assert.False(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -42,7 +41,7 @@ public class TestsForQuery
 
             _dicomDataset.Clear();
 
-            query.Matches(_dicomDataset).Should().BeFalse();
+            Assert.False(query.Matches(_dicomDataset));
         }
 
         [Theory]
@@ -55,7 +54,7 @@ public class TestsForQuery
         {
             var query = new EqualsQuery(DicomTags.AccessionNumber, value);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
     }
 
@@ -66,7 +65,7 @@ public class TestsForQuery
         {
             var query = new NotEqualsQuery(DicomTags.AccessionNumber, "Pineapple");
 
-            query.Matches(_dicomDataset).Should().BeFalse();
+            Assert.False(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -74,7 +73,7 @@ public class TestsForQuery
         {
             var query = new NotEqualsQuery(DicomTags.AccessionNumber, "Pineapple2");
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -84,7 +83,7 @@ public class TestsForQuery
 
             _dicomDataset.Clear();
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Theory]
@@ -97,7 +96,7 @@ public class TestsForQuery
         {
             var query = new NotEqualsQuery(DicomTags.AccessionNumber, value);
 
-            query.Matches(_dicomDataset).Should().BeFalse();
+            Assert.False(query.Matches(_dicomDataset));
         }
 
         [Theory]
@@ -110,7 +109,7 @@ public class TestsForQuery
         {
             var query = new NotEqualsQuery(DicomTags.AccessionNumber, value);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
     }
 
@@ -121,7 +120,7 @@ public class TestsForQuery
         {
             var query = new LowerThanQuery(DicomTags.Rows, "1001", false);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -129,7 +128,7 @@ public class TestsForQuery
         {
             var query = new LowerThanQuery(DicomTags.Rows, "1001", true);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -137,7 +136,7 @@ public class TestsForQuery
         {
             var query = new LowerThanQuery(DicomTags.Rows, "1000", false);
 
-            query.Matches(_dicomDataset).Should().BeFalse();
+            Assert.False(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -145,7 +144,7 @@ public class TestsForQuery
         {
             var query = new LowerThanQuery(DicomTags.Rows, "1000", true);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -153,7 +152,7 @@ public class TestsForQuery
         {
             var query = new LowerThanQuery(DicomTags.AccessionNumber, "Pineapplf", false);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -161,7 +160,7 @@ public class TestsForQuery
         {
             var query = new LowerThanQuery(DicomTags.AccessionNumber, "Pineapplf", true);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -169,7 +168,7 @@ public class TestsForQuery
         {
             var query = new LowerThanQuery(DicomTags.AccessionNumber, "Pineapple", false);
 
-            query.Matches(_dicomDataset).Should().BeFalse();
+            Assert.False(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -177,7 +176,7 @@ public class TestsForQuery
         {
             var query = new LowerThanQuery(DicomTags.AccessionNumber, "Pineapple", true);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -185,7 +184,7 @@ public class TestsForQuery
         {
             var query = new LowerThanQuery(DicomTags.StudyDate, "20200103", false);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -193,7 +192,7 @@ public class TestsForQuery
         {
             var query = new LowerThanQuery(DicomTags.StudyDate, "20200103", true);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -201,7 +200,7 @@ public class TestsForQuery
         {
             var query = new LowerThanQuery(DicomTags.StudyDate, "20200102", false);
 
-            query.Matches(_dicomDataset).Should().BeFalse();
+            Assert.False(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -209,7 +208,7 @@ public class TestsForQuery
         {
             var query = new LowerThanQuery(DicomTags.StudyDate, "20200102", true);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
     }
 
@@ -220,7 +219,7 @@ public class TestsForQuery
         {
             var query = new GreaterThanQuery(DicomTags.Rows, "999", false);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -228,7 +227,7 @@ public class TestsForQuery
         {
             var query = new GreaterThanQuery(DicomTags.Rows, "999", true);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -236,7 +235,7 @@ public class TestsForQuery
         {
             var query = new GreaterThanQuery(DicomTags.Rows, "1000", false);
 
-            query.Matches(_dicomDataset).Should().BeFalse();
+            Assert.False(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -244,7 +243,7 @@ public class TestsForQuery
         {
             var query = new GreaterThanQuery(DicomTags.Rows, "1000", true);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -252,7 +251,7 @@ public class TestsForQuery
         {
             var query = new GreaterThanQuery(DicomTags.AccessionNumber, "Pineappld", false);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -260,7 +259,7 @@ public class TestsForQuery
         {
             var query = new GreaterThanQuery(DicomTags.AccessionNumber, "Pineappld", true);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -268,7 +267,7 @@ public class TestsForQuery
         {
             var query = new GreaterThanQuery(DicomTags.AccessionNumber, "Pineapple", false);
 
-            query.Matches(_dicomDataset).Should().BeFalse();
+            Assert.False(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -276,7 +275,7 @@ public class TestsForQuery
         {
             var query = new GreaterThanQuery(DicomTags.AccessionNumber, "Pineapple", true);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -284,7 +283,7 @@ public class TestsForQuery
         {
             var query = new GreaterThanQuery(DicomTags.StudyDate, "20200101", false);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -292,7 +291,7 @@ public class TestsForQuery
         {
             var query = new GreaterThanQuery(DicomTags.StudyDate, "20200101", true);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -300,7 +299,7 @@ public class TestsForQuery
         {
             var query = new GreaterThanQuery(DicomTags.StudyDate, "20200102", false);
 
-            query.Matches(_dicomDataset).Should().BeFalse();
+            Assert.False(query.Matches(_dicomDataset));
         }
 
         [Fact]
@@ -308,7 +307,7 @@ public class TestsForQuery
         {
             var query = new GreaterThanQuery(DicomTags.StudyDate, "20200102", true);
 
-            query.Matches(_dicomDataset).Should().BeTrue();
+            Assert.True(query.Matches(_dicomDataset));
         }
     }
 }

--- a/tests/DcmFind.Tests/TestsForQueryParser.cs
+++ b/tests/DcmFind.Tests/TestsForQueryParser.cs
@@ -1,5 +1,4 @@
-﻿using FluentAssertions;
-using Xunit;
+﻿using Xunit;
 
 namespace DcmFind.Tests;
 
@@ -11,66 +10,66 @@ public class TestsForQueryParser
     [InlineData("")]
     public void ShouldReturnFalseWhenQueryValueIsNullOrEmpty(string? queryValue)
     {
-        QueryParser.TryParse(queryValue, out _).Should().BeFalse();
+        Assert.False(QueryParser.TryParse(queryValue, out _));
     }
 
     [Fact]
     public void ShouldReturnFalseWhenOperatorIsMissing()
     {
-        QueryParser.TryParse("AccessionNumberPineapple", out _).Should().BeFalse();
+        Assert.False(QueryParser.TryParse("AccessionNumberPineapple", out _));
     }
 
     [Fact]
     public void ShouldReturnFalseWhenOperatorIsUnknown()
     {
-        QueryParser.TryParse("AccessionNumber~Pineapple", out _).Should().BeFalse();
+        Assert.False(QueryParser.TryParse("AccessionNumber~Pineapple", out _));
     }
 
     [Fact]
     public void ShouldReturnFalseWhenDicomTagIsUnknown()
     {
-        QueryParser.TryParse("Banana=Pineapple", out _).Should().BeFalse();
+        Assert.False(QueryParser.TryParse("Banana=Pineapple", out _));
     }
 
     [Fact]
     public void ShouldReturnEqualsQuery()
     {
-        QueryParser.TryParse("AccessionNumber=Pineapple", out var query).Should().BeTrue();
-        query.Should().BeOfType<EqualsQuery>();
+        Assert.True(QueryParser.TryParse("AccessionNumber=Pineapple", out var query));
+        Assert.True((query) is EqualsQuery);
     }
 
     [Fact]
     public void ShouldReturnEqualsQueryEvenIfQueryValueContainsLowerThan()
     {
-        QueryParser.TryParse("AccessionNumber=Pineapple<=3", out var query).Should().BeTrue();
-        query.Should().BeOfType<EqualsQuery>();
+        Assert.True(QueryParser.TryParse("AccessionNumber=Pineapple<=3", out var query));
+        Assert.True((query) is EqualsQuery);
     }
 
     [Fact]
     public void ShouldReturnLowerThanQuery()
     {
-        QueryParser.TryParse("AccessionNumber<=Pineapple", out var query).Should().BeTrue();
-        query.Should().BeOfType<LowerThanQuery>();
+        Assert.True(QueryParser.TryParse("AccessionNumber<=Pineapple", out var query));
+        Assert.True((query) is LowerThanQuery);
     }
 
     [Fact]
     public void ShouldReturnLowerThanQueryEvenIfQueryValueContainsEquals()
     {
-        QueryParser.TryParse("AccessionNumber<=Pineapple=3", out var query).Should().BeTrue();
-        query.Should().BeOfType<LowerThanQuery>();
+        Assert.True(QueryParser.TryParse("AccessionNumber<=Pineapple=3", out var query));
+        Assert.True((query) is LowerThanQuery);
     }
 
     [Fact]
     public void ShouldReturnLowerThanOrEqualsQuery()
     {
-        QueryParser.TryParse("AccessionNumber<Pineapple", out var query).Should().BeTrue();
-        query.Should().BeOfType<LowerThanQuery>();
+        Assert.True(QueryParser.TryParse("AccessionNumber<Pineapple", out var query));
+        Assert.True((query) is LowerThanQuery);
     }
 
     [Fact]
     public void ShouldReturnNotEqualsQuery()
     {
-        QueryParser.TryParse("AccessionNumber!=\"\"", out var query).Should().BeTrue();
-        query.Should().BeOfType<NotEqualsQuery>();
+        Assert.True(QueryParser.TryParse("AccessionNumber!=\"\"", out var query));
+        Assert.True((query) is NotEqualsQuery);
     }
 }

--- a/tests/DcmOrganize.Tests/DcmOrganize.Tests.csproj
+++ b/tests/DcmOrganize.Tests/DcmOrganize.Tests.csproj
@@ -4,7 +4,6 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/DcmOrganize.Tests/HighestDirectoryNameDeterminer.cs
+++ b/tests/DcmOrganize.Tests/HighestDirectoryNameDeterminer.cs
@@ -1,5 +1,4 @@
-﻿using FluentAssertions;
-using Xunit;
+﻿using Xunit;
 
 namespace DcmOrganize.Tests;
 
@@ -20,6 +19,6 @@ public class TestsForHighestDirectoryNameDeterminer
         var highestDirectoryName = HighestDirectoryNameDeterminer.Determine(filePath);
 
         // Assert
-        highestDirectoryName.Should().Be(expectedHighestDirectoryName);
+        Assert.Equal(expectedHighestDirectoryName, highestDirectoryName);
     }
 }

--- a/tests/DcmOrganize.Tests/TestsForDicomTagParser.cs
+++ b/tests/DcmOrganize.Tests/TestsForDicomTagParser.cs
@@ -1,5 +1,4 @@
 using FellowOakDicom;
-using FluentAssertions;
 using Xunit;
 
 namespace DcmOrganize.Tests;
@@ -17,19 +16,19 @@ public class TestsForDicomTagParser
     public void ShouldParseTagByGroupAndElement()
     {
         var dicomTag = _dicomTagParser.Parse("(0008,0050)");
-        dicomTag.Should().Be(DicomTag.AccessionNumber);
+        Assert.Equal(DicomTag.AccessionNumber, dicomTag);
     }
 
     [Fact]
     public void ShouldParseTagByName()
     {
         var dicomTag = _dicomTagParser.Parse("AccessionNumber");
-        dicomTag.Should().Be(DicomTag.AccessionNumber);
+        Assert.Equal(DicomTag.AccessionNumber, dicomTag);
     }
 
     [Fact]
     public void ShouldNotParseUnknownTag()
     {
-        _dicomTagParser.Invoking(p => p.Parse("Banana")).Should().Throw<DicomTagParserException>();
+        Assert.Throws<DicomTagParserException>(() => _dicomTagParser.Parse("Banana"));
     }
 }

--- a/tests/DcmOrganize.Tests/TestsForLinesFromConsoleInputReader.cs
+++ b/tests/DcmOrganize.Tests/TestsForLinesFromConsoleInputReader.cs
@@ -1,5 +1,4 @@
-﻿using FluentAssertions;
-using Xunit;
+﻿using Xunit;
 
 namespace DcmOrganize.Tests;
 
@@ -23,7 +22,7 @@ public class TestsForLinesFromConsoleInputReader : IDisposable
     {
         var lines = await _linesFromConsoleInputReader.Read(CancellationToken.None).ToListAsync();
 
-        lines.Should().BeEmpty();
+        Assert.Empty(lines ?? []);
     }
 
     [Fact]
@@ -34,7 +33,7 @@ public class TestsForLinesFromConsoleInputReader : IDisposable
 
         var lines = await _linesFromConsoleInputReader.Read(CancellationToken.None).ToListAsync();
 
-        lines.Should().BeEquivalentTo(new[] { "Hello world" });
+        Assert.Equivalent(new[] { "Hello world" }, lines);
     }
 
     [Theory]
@@ -48,7 +47,7 @@ public class TestsForLinesFromConsoleInputReader : IDisposable
 
         var lines = await _linesFromConsoleInputReader.Read(CancellationToken.None).ToListAsync();
 
-        lines.Should().BeEquivalentTo(new[] { "Hello", "World" });
+        Assert.Equivalent(new[] { "Hello", "World" }, lines);
     }
 
     public void Dispose()

--- a/tests/DcmOrganize.Tests/TestsForPatternApplier.cs
+++ b/tests/DcmOrganize.Tests/TestsForPatternApplier.cs
@@ -1,5 +1,4 @@
 using FellowOakDicom;
-using FluentAssertions;
 using Xunit;
 
 namespace DcmOrganize.Tests;
@@ -30,7 +29,7 @@ public class TestsForPatternApplier
         var file = _patternApplier.Apply(dicomDataSet, pattern);
 
         // Assert
-        file.Should().Be(Path.Join("ABC123", "7.dcm"));
+        Assert.Equal(Path.Join("ABC123", "7.dcm"), file);
     }
 
     [Fact]
@@ -51,8 +50,10 @@ public class TestsForPatternApplier
         var file = _patternApplier.Apply(dicomDataSet, pattern);
 
         // Assert
-        file.Should()
-            .Be(Path.Join("Patient Samson Gert", "Study ABC123", "Series 20", "Image 7.dcm"));
+        Assert.Equal(
+            Path.Join("Patient Samson Gert", "Study ABC123", "Series 20", "Image 7.dcm"),
+            file
+        );
     }
 
     [Fact]
@@ -70,7 +71,7 @@ public class TestsForPatternApplier
         var file = _patternApplier.Apply(dicomDataSet, pattern);
 
         // Assert
-        file.Should().Be("10.dcm");
+        Assert.Equal("10.dcm", file);
     }
 
     [Fact]
@@ -84,7 +85,7 @@ public class TestsForPatternApplier
         var file = _patternApplier.Apply(dicomDataSet, pattern);
 
         // Assert
-        file.Should().Be("1.2.3.dcm");
+        Assert.Equal("1.2.3.dcm", file);
     }
 
     [Fact]
@@ -100,7 +101,7 @@ public class TestsForPatternApplier
         // Assert
         var guidAsString = file!.Substring(0, file.Length - ".dcm".Length);
 
-        Guid.TryParse(guidAsString, out var _).Should().BeTrue();
+        Assert.True(Guid.TryParse(guidAsString, out var _));
     }
 
     [Fact]
@@ -111,10 +112,7 @@ public class TestsForPatternApplier
         var pattern = "{Banana}.dcm";
 
         // Act
-        _patternApplier
-            .Invoking(p => p.Apply(dicomDataSet, pattern))
-            .Should()
-            .Throw<PatternException>();
+        Assert.Throws<PatternException>(() => _patternApplier.Apply(dicomDataSet, pattern));
     }
 
     [Fact]
@@ -125,6 +123,6 @@ public class TestsForPatternApplier
         var pattern = "{InstanceNumber ?? 'Constant'}.dcm";
 
         // Act
-        _patternApplier.Apply(dicomDataSet, pattern).Should().Be("Constant.dcm");
+        Assert.Equal("Constant.dcm", _patternApplier.Apply(dicomDataSet, pattern));
     }
 }

--- a/tests/DcmSharp.Tests/DcmSharp.Tests.csproj
+++ b/tests/DcmSharp.Tests/DcmSharp.Tests.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/tests/DcmSharp.Tests/TestsForDicomEncoding.cs
+++ b/tests/DcmSharp.Tests/TestsForDicomEncoding.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text;
 using DcmSharp.Parser;
-using FluentAssertions;
 using Xunit.Abstractions;
 
 namespace DcmSharp.Tests;
@@ -24,24 +23,24 @@ public sealed class TestsForDicomEncoding
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetString(DicomTags.SpecificCharacterSet, out string? specificCharacterSet)
-            .Should()
-            .BeTrue();
-        dicomDataset
-            .TryGetPersonName(DicomTags.PatientName, out PersonName patientName)
-            .Should()
-            .BeTrue();
-        dicomDataset
-            .TryGetString(DicomTags.PatientName, out string? patientNameString)
-            .Should()
-            .BeTrue();
+        Assert.True(
+            dicomDataset.TryGetString(
+                DicomTags.SpecificCharacterSet,
+                out string? specificCharacterSet
+            )
+        );
+        Assert.True(
+            dicomDataset.TryGetPersonName(DicomTags.PatientName, out PersonName patientName)
+        );
+        Assert.True(
+            dicomDataset.TryGetString(DicomTags.PatientName, out string? patientNameString)
+        );
 
         // Assert
-        DicomEncoding.TryParse(specificCharacterSet!, out var encoding).Should().BeTrue();
-        encoding.Should().Be(Encoding.Latin1);
-        patientName.GivenName.Should().Be("Jørgen");
-        patientName.FamilyName.Should().Be("Åseline");
-        patientNameString.Should().Be("Åseline^Jørgen");
+        Assert.True(DicomEncoding.TryParse(specificCharacterSet!, out var encoding));
+        Assert.Equal(Encoding.Latin1, encoding);
+        Assert.Equal("Jørgen", patientName.GivenName);
+        Assert.Equal("Åseline", patientName.FamilyName);
+        Assert.Equal("Åseline^Jørgen", patientNameString);
     }
 }

--- a/tests/DcmSharp.Tests/TestsForDicomMultiValues.cs
+++ b/tests/DcmSharp.Tests/TestsForDicomMultiValues.cs
@@ -1,5 +1,4 @@
 ﻿using DcmSharp.Parser;
-using FluentAssertions;
 using Xunit.Abstractions;
 
 namespace DcmSharp.Tests;
@@ -23,13 +22,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetStrings(DicomTags.SelectorAEValue, out string[]? values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetStrings(DicomTags.SelectorAEValue, out string[]? values));
 
         // Assert
-        values.Should().BeEquivalentTo(["MODALITY1", "MODALITY2"]);
+        Assert.Equivalent(new[] { "MODALITY1", "MODALITY2" }, values);
     }
 
     [Fact]
@@ -40,13 +36,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetStrings(DicomTags.SelectorASValue, out string[]? values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetStrings(DicomTags.SelectorASValue, out string[]? values));
 
         // Assert
-        values.Should().BeEquivalentTo(["025Y", "030D"]);
+        Assert.Equivalent(new[] { "025Y", "030D" }, values);
     }
 
     [Fact]
@@ -57,15 +50,13 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetTags(DicomTags.SelectorATValue, out DicomTag[]? values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetTags(DicomTags.SelectorATValue, out DicomTag[]? values));
 
         // Assert
-        values
-            .Should()
-            .BeEquivalentTo([DicomTags.TransferSyntaxUID, DicomTags.ImplementationClassUID]);
+        Assert.Equivalent(
+            new[] { DicomTags.TransferSyntaxUID, DicomTags.ImplementationClassUID },
+            values
+        );
     }
 
     [Fact]
@@ -76,15 +67,13 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetDates(DicomTags.SelectorDAValue, out DateOnly[]? values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetDates(DicomTags.SelectorDAValue, out DateOnly[]? values));
 
         // Assert
-        values
-            .Should()
-            .BeEquivalentTo([DateOnly.Parse("2024-12-03"), DateOnly.Parse("2024-11-03")]);
+        Assert.Equivalent(
+            new[] { DateOnly.Parse("2024-12-03"), DateOnly.Parse("2024-11-03") },
+            values
+        );
     }
 
     [Fact]
@@ -95,13 +84,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetDecimals(DicomTags.SelectorDSValue, out decimal[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetDecimals(DicomTags.SelectorDSValue, out decimal[] values));
 
         // Assert
-        values.Should().BeEquivalentTo([0.25m, 0.50m]);
+        Assert.Equivalent(new[] { 0.25m, 0.50m }, values);
     }
 
     [Fact]
@@ -112,18 +98,13 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetDateTimes(DicomTags.SelectorDTValue, out DateTime[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetDateTimes(DicomTags.SelectorDTValue, out DateTime[] values));
 
         // Assert
-        values
-            .Should()
-            .BeEquivalentTo([
-                DateTime.Parse("2024-12-03T12:00:00"),
-                DateTime.Parse("2024-11-03T12:00:00"),
-            ]);
+        Assert.Equivalent(
+            new[] { DateTime.Parse("2024-12-03T12:00:00"), DateTime.Parse("2024-11-03T12:00:00") },
+            values
+        );
     }
 
     [Fact]
@@ -134,13 +115,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetDoubles(DicomTags.SelectorFDValue, out double[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetDoubles(DicomTags.SelectorFDValue, out double[] values));
 
         // Assert
-        values.Should().BeEquivalentTo([-100.123, 200.456]);
+        Assert.Equivalent(new[] { -100.123, 200.456 }, values);
     }
 
     [Fact]
@@ -151,10 +129,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetFloats(DicomTags.SelectorFLValue, out float[] values).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetFloats(DicomTags.SelectorFLValue, out float[] values));
 
         // Assert
-        values.Should().BeEquivalentTo([100.5f, 200.5]);
+        Assert.Equivalent(new[] { 100.5f, 200.5f }, values);
     }
 
     [Fact]
@@ -165,10 +143,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetInts(DicomTags.SelectorISValue, out int[] values).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetInts(DicomTags.SelectorISValue, out int[] values));
 
         // Assert
-        values.Should().BeEquivalentTo([1, 2]);
+        Assert.Equivalent(new[] { 1, 2 }, values);
     }
 
     [Fact]
@@ -179,13 +157,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetStrings(DicomTags.SelectorLOValue, out string[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetStrings(DicomTags.SelectorLOValue, out string[] values));
 
         // Assert
-        values.Should().BeEquivalentTo(["Medical Center A", "Medical Center B"]);
+        Assert.Equivalent(new[] { "Medical Center A", "Medical Center B" }, values);
     }
 
     [Fact]
@@ -196,13 +171,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetStrings(DicomTags.SelectorLTValue, out string[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetStrings(DicomTags.SelectorLTValue, out string[] values));
 
         // Assert
-        values.Should().BeEquivalentTo(["Some long notes"]);
+        Assert.Equivalent(new[] { "Some long notes" }, values);
     }
 
     [Fact]
@@ -213,15 +185,14 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetPersonNames(DicomTags.SelectorPNValue, out PersonName[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(
+            dicomDataset.TryGetPersonNames(DicomTags.SelectorPNValue, out PersonName[] values)
+        );
 
         // Assert
         var expected1 = new PersonName("Dr", "Smith", null, null, null, null, null, null, null);
         var expected2 = new PersonName("Dr", "Jones", null, null, null, null, null, null, null);
-        values.Should().BeEquivalentTo([expected1, expected2]);
+        Assert.Equivalent(new[] { expected1, expected2 }, values);
     }
 
     [Fact]
@@ -232,13 +203,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetStrings(DicomTags.SelectorSHValue, out string[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetStrings(DicomTags.SelectorSHValue, out string[] values));
 
         // Assert
-        values.Should().BeEquivalentTo(["CT123", "CT456"]);
+        Assert.Equivalent(new[] { "CT123", "CT456" }, values);
     }
 
     [Fact]
@@ -249,10 +217,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetInts(DicomTags.SelectorSLValue, out int[] values).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetInts(DicomTags.SelectorSLValue, out int[] values));
 
         // Assert
-        values.Should().BeEquivalentTo([-1, 2]);
+        Assert.Equivalent(new[] { -1, 2 }, values);
     }
 
     [Fact]
@@ -263,10 +231,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetShorts(DicomTags.SelectorSSValue, out short[] values).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetShorts(DicomTags.SelectorSSValue, out short[] values));
 
         // Assert
-        values.Should().BeEquivalentTo([-32768, 32767]);
+        Assert.Equivalent(new short[] { -32768, 32767 }, values);
     }
 
     [Fact]
@@ -277,13 +245,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetStrings(DicomTags.SelectorSTValue, out string[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetStrings(DicomTags.SelectorSTValue, out string[] values));
 
         // Assert
-        values.Should().BeEquivalentTo(["History1"]);
+        Assert.Equivalent(new[] { "History1" }, values);
     }
 
     [Fact]
@@ -294,10 +259,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetLongs(DicomTags.SelectorSVValue, out long[] values).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetLongs(DicomTags.SelectorSVValue, out long[] values));
 
         // Assert
-        values.Should().BeEquivalentTo([9223372036854775807, -9223372036854775808]);
+        Assert.Equivalent(new[] { 9223372036854775807L, -9223372036854775808L }, values);
     }
 
     [Fact]
@@ -308,13 +273,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetTimes(DicomTags.SelectorTMValue, out TimeOnly[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetTimes(DicomTags.SelectorTMValue, out TimeOnly[] values));
 
         // Assert
-        values.Should().BeEquivalentTo([TimeOnly.Parse("12:00:00"), TimeOnly.Parse("13:00:00")]);
+        Assert.Equivalent(new[] { TimeOnly.Parse("12:00:00"), TimeOnly.Parse("13:00:00") }, values);
     }
 
     [Fact]
@@ -325,13 +287,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetStrings(DicomTags.SelectorUCValue, out string[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetStrings(DicomTags.SelectorUCValue, out string[] values));
 
         // Assert
-        values.Should().BeEquivalentTo(["Device A", "Device B"]);
+        Assert.Equivalent(new[] { "Device A", "Device B" }, values);
     }
 
     [Fact]
@@ -342,13 +301,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetStrings(DicomTags.SelectorUIValue, out string[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetStrings(DicomTags.SelectorUIValue, out string[] values));
 
         // Assert
-        values.Should().BeEquivalentTo(["1.2.3", "4.5.6"]);
+        Assert.Equivalent(new[] { "1.2.3", "4.5.6" }, values);
     }
 
     [Fact]
@@ -359,11 +315,11 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetUInts(DicomTags.SelectorULValue, out uint[] values).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetUInts(DicomTags.SelectorULValue, out uint[] values));
 
         // Assert
         List<uint> expected = [4294967295, 2];
-        values.Should().BeEquivalentTo(expected);
+        Assert.Equivalent(expected, values);
     }
 
     [Fact]
@@ -374,13 +330,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetUShorts(DicomTags.SelectorUSValue, out ushort[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetUShorts(DicomTags.SelectorUSValue, out ushort[] values));
 
         // Assert
-        values.Should().BeEquivalentTo([1, 100]);
+        Assert.Equivalent(new ushort[] { 1, 100 }, values);
     }
 
     [Fact]
@@ -391,13 +344,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetStrings(DicomTags.SelectorUTValue, out string[] values)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetStrings(DicomTags.SelectorUTValue, out string[] values));
 
         // Assert
-        values.Should().BeEquivalentTo(["Modified"]);
+        Assert.Equivalent(new[] { "Modified" }, values);
     }
 
     [Fact]
@@ -408,10 +358,10 @@ public sealed class TestsForDicomMultiValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetULongs(DicomTags.SelectorUVValue, out ulong[] values).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetULongs(DicomTags.SelectorUVValue, out ulong[] values));
 
         // Assert
         List<ulong> expected = [18446744073709551615, 18446744073709551614];
-        values.Should().BeEquivalentTo(expected);
+        Assert.Equivalent(expected, values);
     }
 }

--- a/tests/DcmSharp.Tests/TestsForDicomParser.cs
+++ b/tests/DcmSharp.Tests/TestsForDicomParser.cs
@@ -1,5 +1,4 @@
 using DcmSharp.Parser;
-using FluentAssertions;
 using Xunit.Abstractions;
 
 namespace DcmSharp.Tests;
@@ -23,9 +22,6 @@ public sealed class TestsForDicomParser
 
         // Act + Assert
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
-
-        // Assert
-        dicomDataset.Should().NotBeNull();
     }
 
     [Fact]
@@ -36,9 +32,6 @@ public sealed class TestsForDicomParser
 
         // Act + Assert
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
-
-        // Assert
-        dicomDataset.Should().NotBeNull();
     }
 
     [Theory]
@@ -55,10 +48,10 @@ public sealed class TestsForDicomParser
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetString(group, element, out string? actualValue).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetString(group, element, out string? actualValue));
 
         // Assert
-        actualValue.Should().Be(expectedValue);
+        Assert.Equal(expectedValue, actualValue);
     }
 
     [Theory]
@@ -75,10 +68,10 @@ public sealed class TestsForDicomParser
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetString(group, element, out string? actualValue).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetString(group, element, out string? actualValue));
 
         // Assert
-        actualValue.Should().Be(expectedValue);
+        Assert.Equal(expectedValue, actualValue);
     }
 
     [Fact]
@@ -89,30 +82,29 @@ public sealed class TestsForDicomParser
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act + Assert
-        dicomDataset
-            .TryGetSequence(
+        Assert.True(
+            dicomDataset.TryGetSequence(
                 DicomTags.SourceImageSequence,
                 out ReadOnlyDicomDataset[]? sourceImageSequence
             )
-            .Should()
-            .BeTrue();
-        sourceImageSequence.Should().NotBeNull();
+        );
+        Assert.NotNull(sourceImageSequence);
         var firstSourceImage = sourceImageSequence![0];
-        firstSourceImage.Should().NotBeNull();
-        firstSourceImage
-            .TryGetSequence(
+        Assert.True(
+            firstSourceImage.TryGetSequence(
                 DicomTags.PurposeOfReferenceCodeSequence,
                 out ReadOnlyDicomDataset[]? purposeOfReferenceCodeSequence
             )
-            .Should()
-            .BeTrue();
-        purposeOfReferenceCodeSequence.Should().NotBeNull();
+        );
+        Assert.NotNull(purposeOfReferenceCodeSequence);
         var firstPurposeOfReferenceCodeSequence = purposeOfReferenceCodeSequence![0];
-        firstPurposeOfReferenceCodeSequence
-            .TryGetString(DicomTags.CodeMeaning, out string? codeMeaning)
-            .Should()
-            .BeTrue();
-        codeMeaning.Should().Be("Uncompressed predecessor");
+        Assert.True(
+            firstPurposeOfReferenceCodeSequence.TryGetString(
+                DicomTags.CodeMeaning,
+                out string? codeMeaning
+            )
+        );
+        Assert.Equal("Uncompressed predecessor", codeMeaning);
     }
 
     [Fact]
@@ -123,12 +115,14 @@ public sealed class TestsForDicomParser
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetString(DicomTags.PlacerOrderNumberImagingServiceRequest, out string? orderNumber)
-            .Should()
-            .BeTrue();
+        Assert.True(
+            dicomDataset.TryGetString(
+                DicomTags.PlacerOrderNumberImagingServiceRequest,
+                out string? orderNumber
+            )
+        );
 
         // Assert
-        orderNumber.Should().Be("ORDER2024112213363");
+        Assert.Equal("ORDER2024112213363", orderNumber);
     }
 }

--- a/tests/DcmSharp.Tests/TestsForDicomParserWithStopping.cs
+++ b/tests/DcmSharp.Tests/TestsForDicomParserWithStopping.cs
@@ -1,5 +1,4 @@
 using DcmSharp.Parser;
-using FluentAssertions;
 using Xunit.Abstractions;
 
 namespace DcmSharp.Tests;
@@ -34,18 +33,14 @@ public sealed class TestsForDicomParserWithStopping
         // Act + Assert
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file, options);
 
-        // Assert
-        dicomDataset.Should().NotBeNull();
-
         // The stopping tag should be present
-        dicomDataset.TryGetString(tag, out string? sopInstanceUID).Should().BeTrue();
-        sopInstanceUID.Should().Be("2.25.332838821141227624838581964210008219211");
+        Assert.True(dicomDataset.TryGetString(tag, out string? sopInstanceUID));
+        Assert.Equal("2.25.332838821141227624838581964210008219211", sopInstanceUID);
 
         // This tag comes after the stopping tag, so it should not be present
-        dicomDataset
-            .TryGetString(DicomTags.PlacerOrderNumberImagingServiceRequest, out _)
-            .Should()
-            .BeFalse();
+        Assert.False(
+            dicomDataset.TryGetString(DicomTags.PlacerOrderNumberImagingServiceRequest, out _)
+        );
     }
 
     [Fact]
@@ -67,15 +62,12 @@ public sealed class TestsForDicomParserWithStopping
         // Act + Assert
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file, options);
 
-        // Assert
-        dicomDataset.Should().NotBeNull();
-
         // The stopping tag should be present
-        dicomDataset.TryGetString(tag, out string? sopInstanceUID).Should().BeTrue();
-        sopInstanceUID.Should().Be("1.2.840.113619.2.1.2411.1031152382.365.1.736169244");
+        Assert.True(dicomDataset.TryGetString(tag, out string? sopInstanceUID));
+        Assert.Equal("1.2.840.113619.2.1.2411.1031152382.365.1.736169244", sopInstanceUID);
 
         // This tag comes after the stopping tag, so it should not be present
-        dicomDataset.TryGetString(DicomTags.RescaleType, out _).Should().BeFalse();
+        Assert.False(dicomDataset.TryGetString(DicomTags.RescaleType, out _));
     }
 
     [Fact]
@@ -96,30 +88,29 @@ public sealed class TestsForDicomParserWithStopping
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file, options);
 
         // Act + Assert
-        dicomDataset
-            .TryGetSequence(
+        Assert.True(
+            dicomDataset.TryGetSequence(
                 DicomTags.SourceImageSequence,
                 out ReadOnlyDicomDataset[]? sourceImageSequence
             )
-            .Should()
-            .BeTrue();
-        sourceImageSequence.Should().NotBeNull();
+        );
+        Assert.NotNull(sourceImageSequence);
         var firstSourceImage = sourceImageSequence![0];
-        firstSourceImage.Should().NotBeNull();
-        firstSourceImage
-            .TryGetSequence(
+        Assert.True(
+            firstSourceImage.TryGetSequence(
                 DicomTags.PurposeOfReferenceCodeSequence,
                 out ReadOnlyDicomDataset[]? purposeOfReferenceCodeSequence
             )
-            .Should()
-            .BeTrue();
-        purposeOfReferenceCodeSequence.Should().NotBeNull();
+        );
+        Assert.NotNull(purposeOfReferenceCodeSequence);
         var firstPurposeOfReferenceCodeSequence = purposeOfReferenceCodeSequence![0];
-        firstPurposeOfReferenceCodeSequence
-            .TryGetString(DicomTags.CodeMeaning, out string? codeMeaning)
-            .Should()
-            .BeTrue();
-        codeMeaning.Should().Be("Uncompressed predecessor");
+        Assert.True(
+            firstPurposeOfReferenceCodeSequence.TryGetString(
+                DicomTags.CodeMeaning,
+                out string? codeMeaning
+            )
+        );
+        Assert.Equal("Uncompressed predecessor", codeMeaning);
     }
 
     [Fact]
@@ -140,12 +131,14 @@ public sealed class TestsForDicomParserWithStopping
 
         // Act
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file, options);
-        dicomDataset
-            .TryGetString(DicomTags.PlacerOrderNumberImagingServiceRequest, out string? orderNumber)
-            .Should()
-            .BeTrue();
+        Assert.True(
+            dicomDataset.TryGetString(
+                DicomTags.PlacerOrderNumberImagingServiceRequest,
+                out string? orderNumber
+            )
+        );
 
         // Assert
-        orderNumber.Should().Be("ORDER2024112213363");
+        Assert.Equal("ORDER2024112213363", orderNumber);
     }
 }

--- a/tests/DcmSharp.Tests/TestsForDicomSingleValues.cs
+++ b/tests/DcmSharp.Tests/TestsForDicomSingleValues.cs
@@ -1,5 +1,4 @@
 ﻿using DcmSharp.Parser;
-using FluentAssertions;
 using Xunit.Abstractions;
 
 namespace DcmSharp.Tests;
@@ -23,10 +22,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetString(DicomTags.SelectorAEValue, out string? value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetString(DicomTags.SelectorAEValue, out string? value));
 
         // Assert
-        value.Should().Be("MODALITY1");
+        Assert.Equal("MODALITY1", value);
     }
 
     [Fact]
@@ -37,10 +36,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetString(DicomTags.SelectorASValue, out string? value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetString(DicomTags.SelectorASValue, out string? value));
 
         // Assert
-        value.Should().Be("025Y");
+        Assert.Equal("025Y", value);
     }
 
     [Fact]
@@ -51,10 +50,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetTag(DicomTags.SelectorATValue, out DicomTag? value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetTag(DicomTags.SelectorATValue, out DicomTag? value));
 
         // Assert
-        value.Should().Be(DicomTags.TransferSyntaxUID);
+        Assert.Equal(DicomTags.TransferSyntaxUID, value);
     }
 
     [Fact]
@@ -65,10 +64,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetDate(DicomTags.SelectorDAValue, out DateOnly value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetDate(DicomTags.SelectorDAValue, out DateOnly value));
 
         // Assert
-        value.Should().Be(DateOnly.Parse("2024-12-03"));
+        Assert.Equal(DateOnly.Parse("2024-12-03"), value);
     }
 
     [Fact]
@@ -79,10 +78,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetDecimal(DicomTags.SelectorDSValue, out decimal value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetDecimal(DicomTags.SelectorDSValue, out decimal value));
 
         // Assert
-        value.Should().Be(0.25m);
+        Assert.Equal(0.25m, value);
     }
 
     [Fact]
@@ -93,13 +92,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetDateTime(DicomTags.SelectorDTValue, out DateTime value)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetDateTime(DicomTags.SelectorDTValue, out DateTime value));
 
         // Assert
-        value.Should().Be(DateTime.Parse("2024-12-03T12:00:00"));
+        Assert.Equal(DateTime.Parse("2024-12-03T12:00:00"), value);
     }
 
     [Fact]
@@ -110,10 +106,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetDouble(DicomTags.SelectorFDValue, out double value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetDouble(DicomTags.SelectorFDValue, out double value));
 
         // Assert
-        value.Should().Be(-100.123);
+        Assert.Equal(-100.123, value);
     }
 
     [Fact]
@@ -124,10 +120,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetFloat(DicomTags.SelectorFLValue, out float value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetFloat(DicomTags.SelectorFLValue, out float value));
 
         // Assert
-        value.Should().Be(100.5f);
+        Assert.Equal(100.5f, value);
     }
 
     [Fact]
@@ -138,10 +134,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetInt(DicomTags.SelectorISValue, out int value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetInt(DicomTags.SelectorISValue, out int value));
 
         // Assert
-        value.Should().Be(1);
+        Assert.Equal(1, value);
     }
 
     [Fact]
@@ -152,10 +148,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetString(DicomTags.SelectorLOValue, out string? value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetString(DicomTags.SelectorLOValue, out string? value));
 
         // Assert
-        value.Should().Be("Medical Center A");
+        Assert.Equal("Medical Center A", value);
     }
 
     [Fact]
@@ -166,10 +162,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetString(DicomTags.SelectorLTValue, out string? value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetString(DicomTags.SelectorLTValue, out string? value));
 
         // Assert
-        value.Should().Be("Some long notes");
+        Assert.Equal("Some long notes", value);
     }
 
     [Fact]
@@ -180,14 +176,11 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset
-            .TryGetPersonName(DicomTags.SelectorPNValue, out PersonName value)
-            .Should()
-            .BeTrue();
+        Assert.True(dicomDataset.TryGetPersonName(DicomTags.SelectorPNValue, out PersonName value));
 
         // Assert
         var expected = new PersonName("Dr", "Smith", null, null, null, null, null, null, null);
-        value.Should().Be(expected);
+        Assert.Equal(expected, value);
     }
 
     [Fact]
@@ -198,10 +191,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetString(DicomTags.SelectorSHValue, out string? value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetString(DicomTags.SelectorSHValue, out string? value));
 
         // Assert
-        value.Should().Be("CT123");
+        Assert.Equal("CT123", value);
     }
 
     [Fact]
@@ -212,10 +205,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetInt(DicomTags.SelectorSLValue, out int value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetInt(DicomTags.SelectorSLValue, out int value));
 
         // Assert
-        value.Should().Be(-1);
+        Assert.Equal(-1, value);
     }
 
     [Fact]
@@ -226,10 +219,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetShort(DicomTags.SelectorSSValue, out short value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetShort(DicomTags.SelectorSSValue, out short value));
 
         // Assert
-        value.Should().Be(-32768);
+        Assert.Equal(-32768, value);
     }
 
     [Fact]
@@ -240,10 +233,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetString(DicomTags.SelectorSTValue, out string? value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetString(DicomTags.SelectorSTValue, out string? value));
 
         // Assert
-        value.Should().Be("History1");
+        Assert.Equal("History1", value);
     }
 
     [Fact]
@@ -254,10 +247,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetLong(DicomTags.SelectorSVValue, out long value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetLong(DicomTags.SelectorSVValue, out long value));
 
         // Assert
-        value.Should().Be(9223372036854775807);
+        Assert.Equal(9223372036854775807, value);
     }
 
     [Fact]
@@ -268,10 +261,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetTime(DicomTags.SelectorTMValue, out TimeOnly value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetTime(DicomTags.SelectorTMValue, out TimeOnly value));
 
         // Assert
-        value.Should().Be(TimeOnly.Parse("12:00:00"));
+        Assert.Equal(TimeOnly.Parse("12:00:00"), value);
     }
 
     [Fact]
@@ -282,10 +275,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetString(DicomTags.SelectorUCValue, out string? value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetString(DicomTags.SelectorUCValue, out string? value));
 
         // Assert
-        value.Should().Be("Device A");
+        Assert.Equal("Device A", value);
     }
 
     [Fact]
@@ -296,10 +289,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetString(DicomTags.SelectorUIValue, out string? value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetString(DicomTags.SelectorUIValue, out string? value));
 
         // Assert
-        value.Should().Be("1.2.3");
+        Assert.Equal("1.2.3", value);
     }
 
     [Fact]
@@ -310,10 +303,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetUInt(DicomTags.SelectorULValue, out uint value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetUInt(DicomTags.SelectorULValue, out uint value));
 
         // Assert
-        value.Should().Be(4294967295);
+        Assert.Equal(4294967295, value);
     }
 
     [Fact]
@@ -324,10 +317,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetUShort(DicomTags.SelectorUSValue, out ushort value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetUShort(DicomTags.SelectorUSValue, out ushort value));
 
         // Assert
-        value.Should().Be(1);
+        Assert.Equal(1, value);
     }
 
     [Fact]
@@ -338,10 +331,10 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetString(DicomTags.SelectorUTValue, out string? value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetString(DicomTags.SelectorUTValue, out string? value));
 
         // Assert
-        value.Should().Be("Modified");
+        Assert.Equal("Modified", value);
     }
 
     [Fact]
@@ -352,9 +345,9 @@ public sealed class TestsForDicomSingleValues
         using var dicomDataset = await _dicomParser.ParseReadOnlyAsync(file);
 
         // Act
-        dicomDataset.TryGetULong(DicomTags.SelectorUVValue, out ulong value).Should().BeTrue();
+        Assert.True(dicomDataset.TryGetULong(DicomTags.SelectorUVValue, out ulong value));
 
         // Assert
-        value.Should().Be(18446744073709551615);
+        Assert.Equal(18446744073709551615, value);
     }
 }


### PR DESCRIPTION
Removes FluentAssertions from all test projects and replaces with plain xUnit \Assert.*\ calls.

## Approach
1. Ran [\migrate-fluentassertions\](https://github.com/amoerie/fluentassertions-migrator) tool against the full solution — this handled the majority of conversions automatically
2. Manually fixed remaining patterns the tool could not handle:
   - Multi-line \.Should().BeTrue()/.BeFalse()\ on chained bool \TryGet*\ results
   - \.Should().BeEquivalentTo([...])\ collection assertions → \Assert.Equivalent(new[] { ... }, values)\
   - \.Invoking(...).Should().Throw<>()\ → \Assert.Throws<>()\
   - \Assert.NotNull()\ on \ReadOnlyDicomDataset\ value type (xUnit2002 analyzer error)

## Changes
- Remove \FluentAssertions\ package from \Directory.Packages.props\ and all 4 test \.csproj\ files
- Migrate all test assertion calls in \DcmSharp.Tests\, \DcmFind.Tests\, \DcmOrganize.Tests\, \DcmAnonymize.Tests\

All 5845 tests pass.